### PR TITLE
Improves health checking in several directions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,6 @@ In no particular order:
  * Allow for multiple ZK instances.
  * Cleanly allow for differing namespaces.
  * Allow the use of bound objects instead of instances for things like `ProviderStrategy`.
- * Document various binding options, making it clearer how to configure instances.
+ * Create HealthCheck that returns unhealthy until the initial connection is established.
 
 Cultivar can still help with many of the "unsupported" use cases since it will already manage starting the relevant services, however, they can be made much easier and more automatic.

--- a/cultivar-core/build.gradle
+++ b/cultivar-core/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     "com.google.inject.extensions:guice-multibindings:${libVersions.guice}",
     "com.google.inject.extensions:guice-assistedinject:${libVersions.guice}",
     "com.codahale.metrics:metrics-core:${libVersions.metrics}",
+    "com.codahale.metrics:metrics-healthchecks:${libVersions.metrics}",
   )
   
   compile ("org.apache.curator:curator-recipes:${libVersions.curator}") {

--- a/cultivar-core/src/integTest/java/com/readytalk/cultivar/CuratorModuleIntegTest.java
+++ b/cultivar-core/src/integTest/java/com/readytalk/cultivar/CuratorModuleIntegTest.java
@@ -16,6 +16,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Key;
+import com.readytalk.cultivar.health.HealthCheckModule;
 import com.readytalk.cultivar.test.AbstractZookeeperClusterTest;
 
 public class CuratorModuleIntegTest extends AbstractZookeeperClusterTest {
@@ -31,9 +32,8 @@ public class CuratorModuleIntegTest extends AbstractZookeeperClusterTest {
                 bind(EnsembleProvider.class).annotatedWith(Curator.class).toInstance(
                         new FixedEnsembleProvider(testingCluster.getConnectString()));
                 bind(RetryPolicy.class).annotatedWith(Curator.class).toInstance(new ExponentialBackoffRetry(1000, 3));
-
             }
-        }));
+        }), new HealthCheckModule());
 
     }
 

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/DefaultCultivarStartStopManager.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/DefaultCultivarStartStopManager.java
@@ -3,13 +3,19 @@ package com.readytalk.cultivar;
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.annotations.Beta;
+import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.common.util.concurrent.ServiceManager;
 
 @ThreadSafe
 @Beta
 class DefaultCultivarStartStopManager extends AbstractIdleService implements CultivarStartStopManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultCultivarStartStopManager.class);
 
     private final CuratorManagementService curatorManagementService;
     private final ServiceManager serviceManager;
@@ -23,15 +29,46 @@ class DefaultCultivarStartStopManager extends AbstractIdleService implements Cul
     }
 
     @Override
-    protected void startUp() {
-        curatorManagementService.startAsync().awaitRunning();
+    protected void startUp() throws Exception {
+        try {
+            curatorManagementService.startAsync().awaitRunning();
+        } catch (IllegalStateException ex) {
+            Throwable cause;
+
+            try {
+                cause = curatorManagementService.failureCause();
+            } catch (IllegalStateException ex2) {
+                throw Throwables.propagate(ex);
+            }
+
+            Throwables.propagateIfPossible(cause, Exception.class);
+            throw Throwables.propagate(cause);
+        }
+
         serviceManager.startAsync().awaitHealthy();
+
     }
 
     @Override
-    protected void shutDown() {
-        serviceManager.stopAsync().awaitStopped();
-        curatorManagementService.stopAsync().awaitTerminated();
+    protected void shutDown() throws Exception {
+        try {
+            serviceManager.stopAsync().awaitStopped();
+        } catch (Exception ex) {
+            LOG.warn("Exception when shutting down service manager", ex);
+        }
 
+        try {
+            curatorManagementService.stopAsync().awaitTerminated();
+        } catch (IllegalStateException ex) {
+            Throwable cause;
+            try {
+                cause = curatorManagementService.failureCause();
+            } catch (IllegalStateException ex2) {
+                throw Throwables.propagate(ex);
+            }
+
+            Throwables.propagateIfPossible(cause, Exception.class);
+            throw Throwables.propagate(cause);
+        }
     }
 }

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/DefaultCuratorManagementService.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/DefaultCuratorManagementService.java
@@ -1,6 +1,7 @@
 package com.readytalk.cultivar;
 
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
@@ -9,13 +10,19 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.CuratorListener;
 import org.apache.curator.framework.api.UnhandledErrorListener;
 import org.apache.curator.framework.state.ConnectionStateListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.Beta;
+import com.google.common.base.Stopwatch;
 import com.google.common.util.concurrent.AbstractIdleService;
 
 @ThreadSafe
 @Beta
 public class DefaultCuratorManagementService extends AbstractIdleService implements CuratorManagementService {
+    private static final int MAX_CONNECTION_WAIT_SECONDS = Integer.getInteger("cultivar.connection.wait.seconds", 30);
+
+    private final Logger log;
 
     private final CuratorFramework framework;
 
@@ -27,10 +34,19 @@ public class DefaultCuratorManagementService extends AbstractIdleService impleme
     DefaultCuratorManagementService(@Curator final CuratorFramework framework,
             final Set<ConnectionStateListener> connectionStateListeners, final Set<CuratorListener> curatorListeners,
             final Set<UnhandledErrorListener> unhandledErrorListeners) {
+        this(framework, connectionStateListeners, curatorListeners, unhandledErrorListeners, LoggerFactory
+                .getLogger(DefaultCuratorManagementService.class));
+    }
+
+    DefaultCuratorManagementService(@Curator final CuratorFramework framework,
+            final Set<ConnectionStateListener> connectionStateListeners, final Set<CuratorListener> curatorListeners,
+            final Set<UnhandledErrorListener> unhandledErrorListeners, final Logger log) {
+
         this.framework = framework;
         this.connectionStateListeners = connectionStateListeners;
         this.curatorListeners = curatorListeners;
         this.unhandledErrorListeners = unhandledErrorListeners;
+        this.log = log;
     }
 
     @Override
@@ -49,6 +65,19 @@ public class DefaultCuratorManagementService extends AbstractIdleService impleme
         }
 
         framework.start();
+
+        final Stopwatch start = Stopwatch.createStarted();
+
+        try {
+            if (framework.blockUntilConnected(MAX_CONNECTION_WAIT_SECONDS, TimeUnit.SECONDS)) {
+                log.info("Connected after {} milliseconds", start.elapsed(TimeUnit.MILLISECONDS));
+            } else {
+                log.warn("Failed to connect after {} milliseconds", start.elapsed(TimeUnit.MILLISECONDS));
+            }
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            log.error("Thread interrupted after {} milliseconds", start.elapsed(TimeUnit.MILLISECONDS));
+        }
     }
 
     @Override

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/health/ConnectionHealth.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/health/ConnectionHealth.java
@@ -1,0 +1,58 @@
+package com.readytalk.cultivar.health;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.imps.CuratorFrameworkState;
+import org.apache.zookeeper.data.Stat;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.google.common.base.Stopwatch;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.readytalk.cultivar.Curator;
+
+/**
+ * Pings ZK by checking to ensure that the base namespace path exists. Will return healthy if Curator is not started or
+ * if it has been deliberately stopped.
+ */
+@Singleton
+public class ConnectionHealth extends HealthCheck {
+
+    private static final TimeUnit REPORTING_TIME_UNIT = TimeUnit.NANOSECONDS;
+
+    private final CuratorFramework framework;
+
+    @Inject
+    ConnectionHealth(@Curator final CuratorFramework framework) {
+        this.framework = framework;
+    }
+
+    @Override
+    protected Result check() throws Exception {
+
+        CuratorFrameworkState frameworkState = framework.getState();
+
+        if (CuratorFrameworkState.LATENT.equals(frameworkState) || CuratorFrameworkState.STOPPED.equals(frameworkState)) {
+            return Result.healthy("Framework is in %s state", frameworkState);
+        }
+
+        Stopwatch timer = Stopwatch.createStarted();
+
+        Stat result = framework.checkExists().forPath("/");
+
+        timer.stop();
+
+        Result retval;
+
+        if (result != null) {
+            retval = Result.healthy("Root namespace %s/ found. Result took %s nanoseconds",
+                    String.valueOf(framework.getNamespace()), timer.elapsed(REPORTING_TIME_UNIT));
+        } else {
+            retval = Result.unhealthy("Root namespace %s/ not found! Result took %s nanoseconds",
+                    String.valueOf(framework.getNamespace()), timer.elapsed(REPORTING_TIME_UNIT));
+        }
+
+        return retval;
+    }
+}

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/health/CuratorManagerStatus.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/health/CuratorManagerStatus.java
@@ -1,0 +1,44 @@
+package com.readytalk.cultivar.health;
+
+import static com.google.common.util.concurrent.Service.State.FAILED;
+import static com.google.common.util.concurrent.Service.State.STOPPING;
+import static com.google.common.util.concurrent.Service.State.TERMINATED;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.google.common.util.concurrent.Service.State;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.readytalk.cultivar.CultivarStartStopManager;
+
+/**
+ * Checks to determine if the connection to ZK is either NEW, STARTING, or has started properly. Fails if the
+ * CultivarStartStopManager is in the states FAILED, STOPPING, or TERMINATED.
+ */
+@Singleton
+public class CuratorManagerStatus extends HealthCheck {
+
+    private final CultivarStartStopManager startStopManager;
+
+    @Inject
+    CuratorManagerStatus(final CultivarStartStopManager startStopManager) {
+        this.startStopManager = startStopManager;
+    }
+
+    @Override
+    protected Result check() throws Exception {
+
+        State state = startStopManager.state();
+
+        Result retval;
+
+        if (FAILED.equals(state)) {
+            retval = Result.unhealthy(startStopManager.failureCause());
+        } else if (TERMINATED.equals(state) || STOPPING.equals(state)) {
+            retval = HealthCheck.Result.unhealthy("State is %s!", state);
+        } else {
+            retval = HealthCheck.Result.healthy("Current state is: %s", String.valueOf(state));
+        }
+
+        return retval;
+    }
+}

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/health/HealthcheckModule.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/health/HealthcheckModule.java
@@ -1,0 +1,17 @@
+package com.readytalk.cultivar.health;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
+
+public class HealthCheckModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+
+        Multibinder<HealthCheck> healthchecks = Multibinder.newSetBinder(binder(), HealthCheck.class);
+
+        healthchecks.addBinding().to(ConnectionHealth.class);
+        healthchecks.addBinding().to(CuratorManagerStatus.class);
+    }
+}

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/health/package-info.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/health/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Healthcheck information for ensuring a valid connection to the ZK cluster.
+ */
+@javax.annotation.ParametersAreNonnullByDefault
+package com.readytalk.cultivar.health;

--- a/cultivar-core/src/test/java/com/readytalk/cultivar/DefaultCultivarStartStopManagerTest.java
+++ b/cultivar-core/src/test/java/com/readytalk/cultivar/DefaultCultivarStartStopManagerTest.java
@@ -1,12 +1,17 @@
 package com.readytalk.cultivar;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.when;
 
 import java.util.concurrent.Executor;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
@@ -21,6 +26,9 @@ import com.google.common.util.concurrent.ServiceManager;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DefaultCultivarStartStopManagerTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
 
     @Mock
     private Logger logger;
@@ -42,6 +50,7 @@ public class DefaultCultivarStartStopManagerTest {
             @Override
             protected void startUp() throws Exception {
                 logger.info("startUp");
+
             }
 
             @Override
@@ -64,7 +73,7 @@ public class DefaultCultivarStartStopManagerTest {
     }
 
     @Test
-    public void startUp_StartsCuratorThenServices() {
+    public void startUp_StartsCuratorThenServices() throws Exception {
         startStopManager.startUp();
 
         InOrder order = inOrder(curatorManagementService, logger);
@@ -75,7 +84,104 @@ public class DefaultCultivarStartStopManagerTest {
     }
 
     @Test
-    public void shutDown_ShutsDownServicesThenCurator() {
+    public void startUp_ManagementService_ThrowsException_RethrowsException() {
+        Exception toCatch = new Exception();
+
+        when(curatorManagementService.failureCause()).thenReturn(toCatch);
+        doThrow(new IllegalStateException()).when(curatorManagementService).awaitRunning();
+
+        try {
+            startStopManager.startUp();
+            fail("No exception thrown.");
+        } catch (Exception ex) {
+            assertEquals("Exception caught is not failure cause.", toCatch, ex);
+        }
+
+    }
+
+    @Test
+    public void shutDown_ManagementService_ThrowsException_RethrowsException() {
+        Exception toCatch = new Exception();
+
+        when(curatorManagementService.failureCause()).thenReturn(toCatch);
+        doThrow(new IllegalStateException()).when(curatorManagementService).awaitTerminated();
+
+        try {
+            startStopManager.shutDown();
+            fail("No exception thrown.");
+        } catch (Exception ex) {
+            assertEquals("Exception caught is not failure cause.", toCatch, ex);
+        }
+
+    }
+
+    @Test
+    public void startUp_ManagementService_AwaitThrowsISEWithoutCuratorException_ThrowsISE() {
+        Exception toCatch = new IllegalArgumentException();
+
+        when(curatorManagementService.failureCause()).thenThrow(new IllegalStateException());
+        doThrow(toCatch).when(curatorManagementService).awaitRunning();
+
+        try {
+            startStopManager.startUp();
+            fail("No exception thrown.");
+        } catch (Exception ex) {
+            assertEquals("Exception caught is not failure cause.", toCatch, ex);
+        }
+
+    }
+
+    @Test
+    public void shutDown_ManagementService_AwaitThrowsISEWithoutCuratorException_ThrowsISE() {
+        Exception toCatch = new IllegalArgumentException();
+
+        when(curatorManagementService.failureCause()).thenThrow(new IllegalStateException());
+        doThrow(toCatch).when(curatorManagementService).awaitTerminated();
+
+        try {
+            startStopManager.shutDown();
+            fail("No exception thrown.");
+        } catch (Exception ex) {
+            assertEquals("Exception caught is not failure cause.", toCatch, ex);
+        }
+
+    }
+
+    @Test
+    public void startUp_ServiceManager_StartsTwice_ThrowsISE() throws Exception {
+
+        thrown.expect(IllegalStateException.class);
+
+        // Starting it ensures that it will throw exception for starting twice.
+        serviceManager.startAsync().awaitHealthy();
+
+        startStopManager.startUp();
+    }
+
+    @Test
+    public void startUp_ServiceManager_ServiceThrowsExceptionOnStartup_ThrowsISE() throws Exception {
+        thrown.expect(IllegalStateException.class);
+
+        final Throwable ex = new IllegalArgumentException();
+
+        doThrow(ex).when(logger).info("startUp");
+
+        startStopManager.startUp();
+    }
+
+    @Test
+    public void shutDown_ServiceManager_ServiceThrowsExceptionOnShutdown_DoesNotRethrow() throws Exception {
+        startStopManager.startUp();
+
+        final Throwable ex = new IllegalArgumentException();
+
+        doThrow(ex).when(logger).info("shutDown");
+
+        startStopManager.shutDown();
+    }
+
+    @Test
+    public void shutDown_ShutsDownServicesThenCurator() throws Exception {
         serviceManager.startAsync().awaitHealthy();
         startStopManager.shutDown();
 

--- a/cultivar-core/src/test/java/com/readytalk/cultivar/DefaultCuratorManagementServiceTest.java
+++ b/cultivar-core/src/test/java/com/readytalk/cultivar/DefaultCuratorManagementServiceTest.java
@@ -1,21 +1,31 @@
 package com.readytalk.cultivar;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.CuratorListener;
 import org.apache.curator.framework.api.UnhandledErrorListener;
 import org.apache.curator.framework.listen.Listenable;
 import org.apache.curator.framework.state.ConnectionStateListener;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.Logger;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -43,13 +53,16 @@ public class DefaultCuratorManagementServiceTest {
     @Mock
     private CuratorListener curatorListener;
 
+    @Mock
+    private Logger logger;
+
     private DefaultCuratorManagementService service;
 
     @Before
     public void setUp() throws Exception {
 
         service = new DefaultCuratorManagementService(framework, ImmutableSet.of(connectionStateListener),
-                ImmutableSet.of(curatorListener), ImmutableSet.of(unhandledErrorListener));
+                ImmutableSet.of(curatorListener), ImmutableSet.of(unhandledErrorListener), logger);
 
         when(framework.getConnectionStateListenable()).thenReturn(connectionStateListeners);
 
@@ -59,11 +72,63 @@ public class DefaultCuratorManagementServiceTest {
 
     }
 
+    @After
+    public void tearDown() {
+        // Clear the interrupted flag.
+        try {
+            Thread.sleep(1);
+        } catch (InterruptedException ex) {
+            // Deliberately ignore.
+        }
+    }
+
     @Test
     public void startUp_StartsFramework() {
         service.startUp();
 
         verify(framework).start();
+    }
+
+    @Test
+    public void startUp_BlocksUntilConnectedReturnsTrue_LogsDuration() throws Exception {
+        when(framework.blockUntilConnected(anyInt(), any(TimeUnit.class))).thenReturn(true);
+
+        service.startUp();
+
+        verify(framework).blockUntilConnected(anyInt(), any(TimeUnit.class));
+
+        verify(logger).info(anyString(), anyLong());
+
+        verifyNoMoreInteractions(logger);
+    }
+
+    @Test
+    public void startUp_BlocksUntilConnectedReturnsFalse_LogsWarning() throws Exception {
+        when(framework.blockUntilConnected(anyInt(), any(TimeUnit.class))).thenReturn(false);
+
+        service.startUp();
+
+        verify(framework).blockUntilConnected(anyInt(), any(TimeUnit.class));
+
+        verify(logger).warn(anyString(), anyLong());
+
+        verifyNoMoreInteractions(logger);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void startUp_BlocksUntilConnectedInterrupted_SetsFlagAndLogsError() throws Exception {
+        when(framework.blockUntilConnected(anyInt(), any(TimeUnit.class))).thenThrow(InterruptedException.class);
+
+        service.startUp();
+
+        verify(framework).blockUntilConnected(anyInt(), any(TimeUnit.class));
+
+        verify(logger).error(anyString(), anyLong());
+        verifyNoMoreInteractions(logger);
+
+        assertTrue("Thread not interrupted.", Thread.currentThread().isInterrupted());
+
     }
 
     @Test

--- a/cultivar-core/src/test/java/com/readytalk/cultivar/health/ConnectionHealthTest.java
+++ b/cultivar-core/src/test/java/com/readytalk/cultivar/health/ConnectionHealthTest.java
@@ -1,0 +1,69 @@
+package com.readytalk.cultivar.health;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.api.ExistsBuilder;
+import org.apache.curator.framework.imps.CuratorFrameworkState;
+import org.apache.zookeeper.data.Stat;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConnectionHealthTest {
+
+    @Mock
+    private CuratorFramework framework;
+
+    @Mock
+    private Stat path;
+
+    @Mock
+    private ExistsBuilder existsBuilder;
+
+    private ConnectionHealth test;
+
+    @Before
+    public void setUp() throws Exception {
+
+        when(framework.checkExists()).thenReturn(existsBuilder);
+
+        test = new ConnectionHealth(framework);
+    }
+
+    @Test
+    public void check_FrameworkIsLatent_ReturnsHealthy() throws Exception {
+        when(framework.getState()).thenReturn(CuratorFrameworkState.LATENT);
+
+        assertTrue(test.check().isHealthy());
+    }
+
+    @Test
+    public void check_FrameworkIsStopped_ReturnsHealthy() throws Exception {
+        when(framework.getState()).thenReturn(CuratorFrameworkState.STOPPED);
+
+        assertTrue(test.check().isHealthy());
+    }
+
+    @Test
+    public void check_FrameworkIsStartedAndRootNamespaceExists_ReturnsHealthy() throws Exception {
+        when(framework.getState()).thenReturn(CuratorFrameworkState.STARTED);
+        when(existsBuilder.forPath(anyString())).thenReturn(path);
+
+        assertTrue(test.check().isHealthy());
+    }
+
+    @Test
+    public void check_FrameworkIsStartedAndRootNamespaceDoesNotExist_ReturnsUnHealthy() throws Exception {
+        when(framework.getState()).thenReturn(CuratorFrameworkState.STARTED);
+        when(existsBuilder.forPath(anyString())).thenReturn(null);
+
+        assertFalse(test.check().isHealthy());
+    }
+}

--- a/cultivar-core/src/test/java/com/readytalk/cultivar/health/CuratorManagerStatusTest.java
+++ b/cultivar-core/src/test/java/com/readytalk/cultivar/health/CuratorManagerStatusTest.java
@@ -1,0 +1,73 @@
+package com.readytalk.cultivar.health;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.common.util.concurrent.Service;
+import com.readytalk.cultivar.CultivarStartStopManager;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CuratorManagerStatusTest {
+
+    @Mock
+    private CultivarStartStopManager startStopManager;
+
+    private CuratorManagerStatus test;
+
+    @Before
+    public void setUp() throws Exception {
+        test = new CuratorManagerStatus(startStopManager);
+    }
+
+    @Test
+    public void check_ManagerNotStarted_ReturnsHealthy() throws Exception {
+        when(startStopManager.state()).thenReturn(Service.State.NEW);
+
+        assertTrue(test.check().isHealthy());
+    }
+
+    @Test
+    public void check_ManagerRunning_ReturnsHealthy() throws Exception {
+        when(startStopManager.state()).thenReturn(Service.State.RUNNING);
+
+        assertTrue(test.check().isHealthy());
+    }
+
+    @Test
+    public void check_ManagerFailed_ReturnsUnhealthyWithError() throws Exception {
+        Exception ex = new IOException();
+
+        when(startStopManager.state()).thenReturn(Service.State.FAILED);
+
+        when(startStopManager.failureCause()).thenReturn(ex);
+
+        assertEquals(ex, test.check().getError());
+    }
+
+    @Test
+    public void check_ManagerTerminated_ReturnsUnhealthy() throws Exception {
+
+        when(startStopManager.state()).thenReturn(Service.State.TERMINATED);
+
+        assertFalse(test.check().isHealthy());
+    }
+
+    @Test
+    public void check_ManagerStopping_ReturnsUnhealthy() throws Exception {
+
+        when(startStopManager.state()).thenReturn(Service.State.STOPPING);
+
+        assertFalse(test.check().isHealthy());
+    }
+
+}

--- a/cultivar-core/src/test/java/com/readytalk/cultivar/health/HealthCheckModuleTest.java
+++ b/cultivar-core/src/test/java/com/readytalk/cultivar/health/HealthCheckModuleTest.java
@@ -1,0 +1,49 @@
+package com.readytalk.cultivar.health;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Set;
+
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.ensemble.EnsembleProvider;
+import org.apache.curator.ensemble.fixed.FixedEnsembleProvider;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.google.inject.AbstractModule;
+import com.google.inject.CreationException;
+import com.google.inject.Guice;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import com.readytalk.cultivar.Curator;
+import com.readytalk.cultivar.CuratorModule;
+
+public class HealthCheckModuleTest {
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void createInjector_WithoutCuratorFramework_Fails() {
+        thrown.expect(CreationException.class);
+        Guice.createInjector(new HealthCheckModule());
+    }
+
+    @Test
+    public void createInjector_WithFullCuratorModule_BindsHealthChecks() {
+        assertEquals("Number of health checks not equal to number bound.", 2,
+                Guice.createInjector(new HealthCheckModule(), new CuratorModule(new AbstractModule() {
+                    @Override
+                    protected void configure() {
+                        bind(EnsembleProvider.class).annotatedWith(Curator.class).toInstance(
+                                new FixedEnsembleProvider(""));
+                        bind(RetryPolicy.class).annotatedWith(Curator.class).toInstance(
+                                new ExponentialBackoffRetry(1000, 3));
+                    }
+                })).getInstance(Key.get(new TypeLiteral<Set<HealthCheck>>() {
+                })).size());
+    }
+
+}


### PR DESCRIPTION
1. startUp and shutDown methods on the CultivarStartStopManager now correctly rethrow exceptions.
2. Exceptions in shutdown will not prevent the CuratorFramework from being stopped.
3. Healthchecks were added that ensure proper continuing connection to the ZK cluster.
