### PR TITLE
Names weren't associated with the healthchecks in the registration. 

### DIFF
--- a/cultivar-core/src/main/java/com/readytalk/cultivar/health/HealthCheckModule.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/health/HealthCheckModule.java
@@ -2,16 +2,16 @@ package com.readytalk.cultivar.health;
 
 import com.codahale.metrics.health.HealthCheck;
 import com.google.inject.AbstractModule;
-import com.google.inject.multibindings.Multibinder;
+import com.google.inject.multibindings.MapBinder;
 
 public class HealthCheckModule extends AbstractModule {
 
     @Override
     protected void configure() {
 
-        Multibinder<HealthCheck> healthchecks = Multibinder.newSetBinder(binder(), HealthCheck.class);
+        MapBinder<String, HealthCheck> healthchecks = MapBinder.newMapBinder(binder(), String.class, HealthCheck.class);
 
-        healthchecks.addBinding().to(ConnectionHealth.class);
-        healthchecks.addBinding().to(CuratorManagerStatus.class);
+        healthchecks.addBinding("cultivar.connection").to(ConnectionHealth.class);
+        healthchecks.addBinding("cultivar.manager.status").to(CuratorManagerStatus.class);
     }
 }

--- a/cultivar-core/src/test/java/com/readytalk/cultivar/health/HealthCheckModuleTest.java
+++ b/cultivar-core/src/test/java/com/readytalk/cultivar/health/HealthCheckModuleTest.java
@@ -2,6 +2,7 @@ package com.readytalk.cultivar.health;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.curator.RetryPolicy;
@@ -42,7 +43,7 @@ public class HealthCheckModuleTest {
                         bind(RetryPolicy.class).annotatedWith(Curator.class).toInstance(
                                 new ExponentialBackoffRetry(1000, 3));
                     }
-                })).getInstance(Key.get(new TypeLiteral<Set<HealthCheck>>() {
+                })).getInstance(Key.get(new TypeLiteral<Map<String, HealthCheck>>() {
                 })).size());
     }
 


### PR DESCRIPTION
Previously the healthchecks were being registered with a set multibinder. This meant that the names weren't being associated with the individual healthchecks when it came time to register them. Fixed. 
