### PR TITLE
Adding tools to use Curator's NodeCache facilities.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ Curator is in many ways a great framework, but it is rather unopinionated about 
  * You are using Guice or can at least figure out how to strap a few Guice modules into your application lifecycle.
  * You know what Curator objects you will need around the time your application starts up (this will change in the future as an absolute requirement, but is still going to be the primary method of using Cultivar).
  * Your use cases in how you access services are relatively homogenous (so if you access service A using a round-robin strategy from Service X you will probably use a round robin strategy from Service Y as well) and you want the ability to share these practices in the form of a client library.
+ 
+Philosophy
+----------
+
+Core principles behind using Cultivar:
+
+* Builders are used for constructing Guice Modules that inject specific objects.
+* Construction of objects is, to the degree that it is reasonable, *fail-fast*. If Cultivar knows that a value should not be `null`, it will try to tell you that when you set the value, rather than at the time the `Module` is built. If something is required for a `Module` to be constructed, it will try to tell you at the time the `Module` is constructed, rather than at the time the Injector is built, etc. 
+* The lifecycle of most objects in the most common use cases is to spin everything up at approximately the same time when the application starts, then to tear it down when the application is shut down.
+* Modules should be *reusable* between applications using a client library.  
+* In the general case, you are using Curator objects directly or using encapsulation, rather than inheritance. 
 
 Building and Testing
 --------------------
@@ -219,5 +230,6 @@ In no particular order:
  * Cleanly allow for differing namespaces.
  * Allow the use of bound objects instead of instances for things like `ProviderStrategy`.
  * Create HealthCheck that returns unhealthy until the initial connection is established.
+ * Switch from `Preconditions` to `Verification` where appropriate. 
 
 Cultivar can still help with many of the "unsupported" use cases since it will already manage starting the relevant services, however, they can be made much easier and more automatic.

--- a/cultivar-core/src/integTest/java/com/readytalk/cultivar/cache/NodeContainerIntegTest.java
+++ b/cultivar-core/src/integTest/java/com/readytalk/cultivar/cache/NodeContainerIntegTest.java
@@ -1,0 +1,155 @@
+package com.readytalk.cultivar.cache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.ensemble.EnsembleProvider;
+import org.apache.curator.ensemble.fixed.FixedEnsembleProvider;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.cache.NodeCacheListener;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.base.Charsets;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Stage;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Names;
+import com.readytalk.cultivar.CultivarStartStopManager;
+import com.readytalk.cultivar.Curator;
+import com.readytalk.cultivar.CuratorModule;
+import com.readytalk.cultivar.test.AbstractZookeeperClusterTest;
+import com.readytalk.cultivar.test.ConditionalWait;
+import com.readytalk.cultivar.util.mapping.StringUTF8ByteArrayMapper;
+
+public class NodeContainerIntegTest extends AbstractZookeeperClusterTest {
+
+    private CultivarStartStopManager manager;
+
+    private CuratorFramework framework;
+
+    private NodeContainer<String> container;
+
+    @Before
+    public void setUp() throws Exception {
+        Injector inj = Guice.createInjector(
+                Stage.PRODUCTION,
+                new CuratorModule(new AbstractModule() {
+                    @Override
+                    protected void configure() {
+                        bind(EnsembleProvider.class).annotatedWith(Curator.class).toInstance(
+                                new FixedEnsembleProvider(testingCluster.getConnectString()));
+                        bind(RetryPolicy.class).annotatedWith(Curator.class).toInstance(
+                                new ExponentialBackoffRetry(10, 10));
+
+                    }
+                }),
+                new AbstractModule() {
+                    @Override
+                    protected void configure() {
+
+                        bindConstant().annotatedWith(Names.named("Cultivar.Curator.baseNamespace")).to("dev/test");
+                    }
+                },
+                NodeContainerModuleBuilder.create(String.class).annotation(Curator.class)
+                        .mapper(StringUTF8ByteArrayMapper.class).path("/dev/test").build());
+
+        manager = inj.getInstance(CultivarStartStopManager.class);
+
+        framework = inj.getInstance(Key.get(CuratorFramework.class, Curator.class));
+
+        container = inj.getInstance(Key.get(new TypeLiteral<NodeContainer<String>>() {
+        }, Curator.class));
+
+        manager.startAsync().awaitRunning();
+    }
+
+    @After
+    public void tearDown() {
+        manager.stopAsync().awaitTerminated();
+    }
+
+    @Test
+    public void get_Uninitialized_Null() {
+        assertNull(container.get());
+    }
+
+    @Test
+    public void getWithDefault_Uninitialized_Value() {
+        String value = "test";
+
+        assertEquals(value, container.get(value));
+    }
+
+    @Test
+    public void createValue_PropagatesToNode() throws Exception {
+        String value = "foo";
+
+        framework.create().creatingParentsIfNeeded().forPath("/dev/test", value.getBytes(Charsets.UTF_8));
+
+        new ConditionalWait(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return container.get() != null;
+            }
+        }).await();
+
+        assertEquals(value, container.get());
+    }
+
+    @Test
+    public void createValue_AfterPropagation_ReturnsValueWhenDefaultSpecified() throws Exception {
+        String value = "foo";
+
+        framework.create().creatingParentsIfNeeded().forPath("/dev/test", value.getBytes(Charsets.UTF_8));
+
+        new ConditionalWait(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return container.get() != null;
+            }
+        }).await();
+
+        assertEquals(value, container.get("notCorrect"));
+    }
+
+    @Test
+    public void createValue_PropagatesToNodeOnRebuild() throws Exception {
+        String value = "foo";
+
+        framework.create().creatingParentsIfNeeded().forPath("/dev/test", value.getBytes(Charsets.UTF_8));
+
+        container.rebuild();
+
+        assertEquals(value, container.get());
+    }
+
+    @Test
+    public void createValue_TriggersListenerOnPropagate() throws Exception {
+        String value = "foo";
+
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        container.addListener(new NodeCacheListener() {
+            @Override
+            public void nodeChanged() throws Exception {
+                latch.countDown();
+            }
+        });
+
+        framework.create().creatingParentsIfNeeded().forPath("/dev/test", value.getBytes(Charsets.UTF_8));
+
+        latch.await();
+
+        assertEquals(value, container.get());
+    }
+}

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/cache/DefaultNodeContainer.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/cache/DefaultNodeContainer.java
@@ -1,0 +1,104 @@
+package com.readytalk.cultivar.cache;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.concurrent.Executor;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.NodeCache;
+import org.apache.curator.framework.recipes.cache.NodeCacheListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.inject.Inject;
+import com.readytalk.cultivar.CuratorService;
+import com.readytalk.cultivar.internal.Private;
+import com.readytalk.cultivar.util.mapping.ByteArrayMapper;
+
+@ThreadSafe
+public class DefaultNodeContainer<T> extends AbstractIdleService implements CuratorService, NodeContainer<T> {
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultNodeContainer.class);
+
+    private final NodeCache cache;
+    private final ByteArrayMapper<T> mapper;
+
+    @Inject
+    DefaultNodeContainer(@Private final NodeCache cache, @Private final ByteArrayMapper<T> mapper) {
+        this.cache = cache;
+        this.mapper = mapper;
+    }
+
+    @Override
+    @Nullable
+    public T get() {
+
+        ChildData data = cache.getCurrentData();
+
+        if (data == null) {
+            return null;
+        }
+
+        byte[] bytes = data.getData();
+
+        if (bytes == null) {
+            return null;
+        }
+
+        return mapper.map(bytes);
+    }
+
+    @Override
+    public T get(final T def) {
+        ChildData data = cache.getCurrentData();
+
+        if (data == null) {
+            return def;
+        }
+
+        byte[] bytes = data.getData();
+
+        return mapper.map(bytes, def);
+    }
+
+    @Override
+    public void addListener(final NodeCacheListener listener) {
+        this.cache.getListenable().addListener(checkNotNull(listener));
+    }
+
+    @Override
+    public void addListener(final NodeCacheListener listener, final Executor executor) {
+        this.cache.getListenable().addListener(checkNotNull(listener), checkNotNull(executor));
+    }
+
+    /**
+     * Rebuilds the cache, logging Exceptions.
+     *
+     * @throws java.lang.IllegalStateException
+     *             If the cache has not been started yet.
+     */
+    @Override
+    public synchronized void rebuild() {
+        try {
+            cache.rebuild();
+        } catch (IllegalStateException ex) {
+            throw Throwables.propagate(ex);
+        } catch (Exception ex) {
+            LOG.warn("Exception when rebuilding cache.", ex);
+        }
+    }
+
+    @Override
+    protected void startUp() throws Exception {
+        cache.start(true);
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
+        cache.close();
+    }
+}

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/cache/NodeCacheProvider.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/cache/NodeCacheProvider.java
@@ -1,0 +1,29 @@
+package com.readytalk.cultivar.cache;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.cache.NodeCache;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.name.Named;
+import com.readytalk.cultivar.Curator;
+
+class NodeCacheProvider implements Provider<NodeCache> {
+
+    private final CuratorFramework client;
+    private final String path;
+    private final boolean compressedData;
+
+    @Inject
+    NodeCacheProvider(@Curator final CuratorFramework client, @Named("Cultivar.cache.path") final String path,
+            @Named("Cultivar.cache.compressed") final boolean compressedData) {
+        this.client = client;
+        this.path = path;
+        this.compressedData = compressedData;
+    }
+
+    @Override
+    public NodeCache get() {
+        return new NodeCache(client, path, compressedData);
+    }
+}

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/cache/NodeContainer.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/cache/NodeContainer.java
@@ -1,0 +1,51 @@
+package com.readytalk.cultivar.cache;
+
+import java.util.concurrent.Executor;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+import org.apache.curator.framework.recipes.cache.NodeCacheListener;
+
+import com.readytalk.cultivar.CuratorService;
+
+/**
+ * Represents a NodeCache object with some convenience wrapping to facilitate easier value checking. Does not
+ * distinguish between a node not being present and it being set to null as a value.
+ *
+ * Thread safe, but is only guaranteed to be as consistent as the underlying NodeCache.
+ */
+@ThreadSafe
+public interface NodeContainer<T> extends CuratorService {
+    /**
+     * Retrieve the value of the node.
+     * 
+     * @return The value of the node, mapped to the type T. Returns null if the node does not exist or if the data is
+     *         null.
+     */
+    @Nullable
+    T get();
+
+    /**
+     * Retrieve the value of the node or a default.
+     * 
+     * @return The value of the node, mapped to the type T. Returns def if the node does not exist or if the data is
+     *         null.
+     */
+    T get(T def);
+
+    /**
+     * Add a listener to the NodeCache.
+     */
+    void addListener(NodeCacheListener listener);
+
+    /**
+     * Add a listener to the NodeCache to be run with the given executor.
+     */
+    void addListener(NodeCacheListener listener, Executor executor);
+
+    /**
+     * Rebuild the cache, not notifying listeners of changes.
+     */
+    void rebuild();
+}

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/cache/NodeContainerModuleBuilder.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/cache/NodeContainerModuleBuilder.java
@@ -1,0 +1,117 @@
+package com.readytalk.cultivar.cache;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import java.lang.annotation.Annotation;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import org.apache.curator.framework.recipes.cache.NodeCache;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.PrivateModule;
+import com.google.inject.Singleton;
+import com.google.inject.multibindings.Multibinder;
+import com.google.inject.name.Names;
+import com.google.inject.util.Types;
+import com.readytalk.cultivar.CuratorService;
+import com.readytalk.cultivar.internal.AnnotationHolder;
+import com.readytalk.cultivar.internal.Private;
+import com.readytalk.cultivar.util.mapping.ByteArrayMapper;
+import com.readytalk.cultivar.util.mapping.NOPByteArrayMapper;
+
+@NotThreadSafe
+public class NodeContainerModuleBuilder<T> {
+
+    private final Class<T> objectType;
+    private boolean compressed = false;
+
+    private Class<? extends ByteArrayMapper<T>> mapper = null;
+    private String path = null;
+    private AnnotationHolder annotationHolder = null;
+
+    NodeContainerModuleBuilder(final Class<T> objectType) {
+        this.objectType = objectType;
+    }
+
+    public static <T> NodeContainerModuleBuilder<T> create(final Class<T> objectType) {
+        return new NodeContainerModuleBuilder<T>(checkNotNull(objectType));
+    }
+
+    /**
+     * Creates a NodeContainerModuleBuilder with the default (byte[]) type and with a NOP mapper.
+     */
+    public static NodeContainerModuleBuilder<byte[]> create() {
+        return create(byte[].class).mapper(NOPByteArrayMapper.class);
+    }
+
+    public NodeContainerModuleBuilder<T> annotation(final Class<? extends Annotation> ann) {
+        annotationHolder = AnnotationHolder.create(ann);
+
+        return this;
+    }
+
+    public NodeContainerModuleBuilder<T> annotation(final Annotation ann) {
+        annotationHolder = AnnotationHolder.create(ann);
+
+        return this;
+    }
+
+    public NodeContainerModuleBuilder<T> path(final String nodePath) {
+        this.path = checkNotNull(nodePath);
+
+        return this;
+    }
+
+    public NodeContainerModuleBuilder<T> compressed() {
+        this.compressed = true;
+
+        return this;
+    }
+
+    public NodeContainerModuleBuilder<T> mapper(final Class<? extends ByteArrayMapper<T>> mapperClass) {
+        this.mapper = checkNotNull(mapperClass);
+
+        return this;
+    }
+
+    public Module build() {
+        checkState(mapper != null, "Mapper has not been set.");
+        checkState(path != null, "Path has not been set.");
+        checkState(annotationHolder != null, "Annotation has not been set.");
+
+        return new AbstractModule() {
+            @Override
+            @SuppressWarnings("unchecked")
+            protected void configure() {
+                final Key<NodeContainer<T>> nodeContainerKey = (Key<NodeContainer<T>>) annotationHolder
+                        .generateKey(Types.newParameterizedType(NodeContainer.class, objectType));
+
+                install(new PrivateModule() {
+                    @Override
+                    protected void configure() {
+                        bind(NodeCache.class).annotatedWith(Private.class).toProvider(NodeCacheProvider.class)
+                                .in(Singleton.class);
+                        bindConstant().annotatedWith(Names.named("Cultivar.cache.path")).to(path);
+                        bindConstant().annotatedWith(Names.named("Cultivar.cache.compressed")).to(compressed);
+
+                        bind(
+                                (Key<ByteArrayMapper<T>>) Key.get(
+                                        Types.newParameterizedType(ByteArrayMapper.class, objectType), Private.class))
+                                .to(mapper);
+
+                        bind(nodeContainerKey).to(
+                                (Key<DefaultNodeContainer<T>>) Key.get(Types.newParameterizedType(
+                                        DefaultNodeContainer.class, objectType))).in(Singleton.class);
+                        expose(nodeContainerKey);
+                    }
+                });
+
+                Multibinder.newSetBinder(binder(), CuratorService.class).addBinding().to(nodeContainerKey);
+            }
+        };
+    }
+}

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/cache/package-info.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/cache/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Tools for working with the Cache facilities in Curator.
+ */
+@javax.annotation.ParametersAreNonnullByDefault
+package com.readytalk.cultivar.cache;

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/util/mapping/AbstractByteArrayMapper.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/util/mapping/AbstractByteArrayMapper.java
@@ -1,0 +1,20 @@
+package com.readytalk.cultivar.util.mapping;
+
+import javax.annotation.Nullable;
+
+public abstract class AbstractByteArrayMapper<T> implements ByteArrayMapper<T> {
+
+    protected AbstractByteArrayMapper() {
+
+    }
+
+    @Override
+    public T map(@Nullable final byte[] bytes, final T defaultValue) {
+
+        if (bytes == null) {
+            return defaultValue;
+        }
+
+        return map(bytes);
+    }
+}

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/util/mapping/BooleanUTF8ByteArrayMapper.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/util/mapping/BooleanUTF8ByteArrayMapper.java
@@ -1,0 +1,19 @@
+package com.readytalk.cultivar.util.mapping;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Charsets;
+import com.google.inject.Inject;
+
+public class BooleanUTF8ByteArrayMapper extends AbstractByteArrayMapper<Boolean> {
+    @Inject
+    public BooleanUTF8ByteArrayMapper() {
+
+    }
+
+    @Override
+    public Boolean map(final byte[] bytes) {
+
+        return Boolean.valueOf(new String(checkNotNull(bytes), Charsets.UTF_8));
+    }
+}

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/util/mapping/ByteArrayMapper.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/util/mapping/ByteArrayMapper.java
@@ -1,0 +1,9 @@
+package com.readytalk.cultivar.util.mapping;
+
+import javax.annotation.Nullable;
+
+public interface ByteArrayMapper<T> {
+    T map(byte[] bytes);
+
+    T map(@Nullable byte[] bytes, T defaultValue);
+}

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/util/mapping/NOPByteArrayMapper.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/util/mapping/NOPByteArrayMapper.java
@@ -1,0 +1,21 @@
+package com.readytalk.cultivar.util.mapping;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.inject.Inject;
+
+/**
+ * Returns a given byte array.
+ */
+public class NOPByteArrayMapper extends AbstractByteArrayMapper<byte[]> {
+
+    @Inject
+    public NOPByteArrayMapper() {
+
+    }
+
+    @Override
+    public byte[] map(final byte[] bytes) {
+        return checkNotNull(bytes);
+    }
+}

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/util/mapping/StringUTF8ByteArrayMapper.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/util/mapping/StringUTF8ByteArrayMapper.java
@@ -1,0 +1,20 @@
+package com.readytalk.cultivar.util.mapping;
+
+
+import com.google.common.base.Charsets;
+import com.google.inject.Inject;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class StringUTF8ByteArrayMapper extends AbstractByteArrayMapper<String> {
+
+    @Inject
+    public StringUTF8ByteArrayMapper() {
+
+    }
+
+    @Override
+    public String map(final byte[] bytes) {
+        return new String(checkNotNull(bytes), Charsets.UTF_8);
+    }
+}

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/util/mapping/package-info.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/util/mapping/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Tools for mapping values from byte arrays. These are simple utilities that are not meant to replace tools such as
+ * Jackson, but rather to provide a facade and facilitate simple use cases.
+ */
+@javax.annotation.ParametersAreNonnullByDefault
+package com.readytalk.cultivar.util.mapping;

--- a/cultivar-core/src/test/java/com/readytalk/cultivar/cache/DefaultNodeContainerTest.java
+++ b/cultivar-core/src/test/java/com/readytalk/cultivar/cache/DefaultNodeContainerTest.java
@@ -1,0 +1,196 @@
+package com.readytalk.cultivar.cache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.Executor;
+
+import org.apache.curator.framework.listen.ListenerContainer;
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.NodeCache;
+import org.apache.curator.framework.recipes.cache.NodeCacheListener;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import com.readytalk.cultivar.util.mapping.ByteArrayMapper;
+
+@SuppressWarnings("ConstantConditions")
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultNodeContainerTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    private final Object returnObject = new Object();
+
+    @Mock
+    private NodeCache cache;
+
+    @Mock
+    private Executor executor;
+
+    @Mock
+    private NodeCacheListener listener;
+
+    @Mock
+    private ByteArrayMapper<Object> mapper;
+
+    @Mock
+    private ListenerContainer<NodeCacheListener> listenerContainer;
+
+    @Mock
+    private ChildData childData;
+
+    private DefaultNodeContainer<Object> container;
+
+    @Before
+    public void setUp() {
+        when(cache.getListenable()).thenReturn(listenerContainer);
+        when(mapper.map(any(byte[].class), any())).thenAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                return invocation.getArguments()[1];
+            }
+        });
+
+        when(cache.getCurrentData()).thenReturn(childData);
+
+        container = new DefaultNodeContainer<Object>(cache, mapper);
+    }
+
+    @Test
+    public void startUp_StartsCacheWithCreateInitial() throws Exception {
+        container.startUp();
+
+        verify(cache).start(true);
+    }
+
+    @Test
+    public void shutDown_ClosesCache() throws Exception {
+        container.shutDown();
+
+        verify(cache).close();
+    }
+
+    @Test
+    public void addListener_AddsListenerToCache() {
+        container.addListener(listener);
+
+        verify(listenerContainer).addListener(listener);
+    }
+
+    @Test
+    public void addListener_NullListener_ThrowsNPE() {
+        thrown.expect(NullPointerException.class);
+
+        container.addListener(null);
+    }
+
+    @Test
+    public void addListenerWithExecutor_AddsListenerToCache() {
+        container.addListener(listener, executor);
+
+        verify(listenerContainer).addListener(listener, executor);
+    }
+
+    @Test
+    public void addListenerWithExecutor_NullListener_ThrowsNPE() {
+        thrown.expect(NullPointerException.class);
+
+        container.addListener((NodeCacheListener) null, executor);
+    }
+
+    @Test
+    public void addListenerWithExecutor_NullExecutor_ThrowsNPE() {
+        thrown.expect(NullPointerException.class);
+
+        container.addListener(listener, null);
+    }
+
+    @Test
+    public void get_ChildDataContainsBytes_ReturnMapperResult() {
+        byte[] bytes = new byte[] { 0x01 };
+        when(childData.getData()).thenReturn(bytes);
+        when(mapper.map(bytes)).thenReturn(returnObject);
+
+        assertEquals(returnObject, container.get());
+    }
+
+    @Test
+    public void get_ChildDataContainsNull_ReturnNull() {
+        when(childData.getData()).thenReturn(null);
+
+        assertNull(container.get());
+    }
+
+    @Test
+    public void get_ChildDataIsNull_ReturnNull() {
+        when(cache.getCurrentData()).thenReturn(null);
+
+        assertNull(container.get());
+    }
+
+    @Test
+    public void getWithDefault_ChildDataContainsBytes_ReturnMapperResult() {
+        byte[] bytes = new byte[] { 0x01 };
+        when(childData.getData()).thenReturn(bytes);
+        when(mapper.map(eq(bytes), any())).thenReturn(returnObject);
+
+        assertEquals(returnObject, container.get(new Object()));
+    }
+
+    @Test
+    public void getWithDefault_ChildDataContainsNull_ReturnDefault() {
+
+        Object defaultReturn = new Object();
+
+        when(childData.getData()).thenReturn(null);
+
+        assertEquals(defaultReturn, container.get(defaultReturn));
+    }
+
+    @Test
+    public void getWithDefault_ChildDataIsNull_ReturnDefault() {
+
+        Object defaultReturn = new Object();
+
+        when(cache.getCurrentData()).thenReturn(null);
+
+        assertEquals(defaultReturn, container.get(defaultReturn));
+    }
+
+    @Test
+    public void rebuild_RebuildsCache() throws Exception {
+        container.rebuild();
+
+        verify(cache).rebuild();
+    }
+
+    @Test
+    public void rebuild_GeneralExceptionWhileRebuilding_DoesNotRethrow() throws Exception {
+        doThrow(new Exception()).when(cache).rebuild();
+
+        container.rebuild();
+    }
+
+    @Test
+    public void rebuild_ISEWhileRebuilding_RethrowsException() throws Exception {
+        thrown.expect(IllegalStateException.class);
+
+        doThrow(new IllegalStateException()).when(cache).rebuild();
+
+        container.rebuild();
+    }
+}

--- a/cultivar-core/src/test/java/com/readytalk/cultivar/cache/NodeCacheProviderTest.java
+++ b/cultivar-core/src/test/java/com/readytalk/cultivar/cache/NodeCacheProviderTest.java
@@ -1,0 +1,38 @@
+package com.readytalk.cultivar.cache;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.utils.EnsurePath;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NodeCacheProviderTest {
+
+    @Mock
+    private CuratorFramework framework;
+
+    @Mock
+    private EnsurePath ensurePath;
+
+    private NodeCacheProvider provider;
+
+    @Before
+    public void setUp() throws Exception {
+        final String path = "/dev/test";
+
+        when(framework.newNamespaceAwareEnsurePath(path)).thenReturn(ensurePath);
+
+        provider = new NodeCacheProvider(framework, path, true);
+    }
+
+    @Test
+    public void get_ReturnsNonNull() {
+        assertNotNull(provider.get());
+    }
+}

--- a/cultivar-core/src/test/java/com/readytalk/cultivar/cache/NodeContainerModuleBuilderTest.java
+++ b/cultivar-core/src/test/java/com/readytalk/cultivar/cache/NodeContainerModuleBuilderTest.java
@@ -1,0 +1,211 @@
+package com.readytalk.cultivar.cache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.utils.EnsurePath;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.CreationException;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import com.google.inject.Stage;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Names;
+import com.google.inject.util.Types;
+import com.readytalk.cultivar.Curator;
+import com.readytalk.cultivar.CuratorService;
+import com.readytalk.cultivar.util.mapping.StringUTF8ByteArrayMapper;
+
+@RunWith(Enclosed.class)
+public class NodeContainerModuleBuilderTest {
+
+    @SuppressWarnings("ConstantConditions")
+    public static class CreationTest {
+        @Rule
+        public final ExpectedException thrown = ExpectedException.none();
+
+        @Test
+        public void create_Null_ThrowsNPE() {
+            thrown.expect(NullPointerException.class);
+
+            NodeContainerModuleBuilder.create(null);
+        }
+
+        @Test
+        public void create_NoArguments_IsNotNull() {
+            assertNotNull(NodeContainerModuleBuilder.create());
+        }
+
+        @Test
+        public void create_WithArguments_IsNotNull() {
+            assertNotNull(NodeContainerModuleBuilder.create(String.class));
+        }
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @RunWith(MockitoJUnitRunner.class)
+    public static class BuilderTest {
+
+        @Rule
+        public final ExpectedException thrown = ExpectedException.none();
+
+        private NodeContainerModuleBuilder<String> builder;
+
+        @Before
+        public void setUp() throws Exception {
+            builder = NodeContainerModuleBuilder.create(String.class);
+        }
+
+        @Test
+        public void mapper_ReturnsSelf() {
+            assertEquals(builder, builder.mapper(StringUTF8ByteArrayMapper.class));
+        }
+
+        @Test
+        public void mapper_NullValue_ThrowsNPE() {
+            thrown.expect(NullPointerException.class);
+
+            builder.mapper(null);
+        }
+
+        @Test
+        public void path_NullValue_ThrowsNPE() {
+            thrown.expect(NullPointerException.class);
+
+            builder.path(null);
+        }
+
+        @Test
+        public void path_ReturnsSelf() {
+
+            assertEquals(builder, builder.path("/dev/test"));
+        }
+
+        @Test
+        public void annotationWithClass_ReturnsSelf() {
+
+            assertEquals(builder, builder.annotation(Curator.class));
+        }
+
+        @Test
+        public void annotationWithAnnotation_ReturnsSelf() {
+
+            assertEquals(builder, builder.annotation(Names.named("test")));
+        }
+
+        @Test
+        public void compressed_ReturnsSelf() {
+
+            assertEquals(builder, builder.compressed());
+        }
+
+        @Test
+        public void build_WithPathAndAnnotationAndNoMapperSet_ThrowsISE() {
+            thrown.expect(IllegalStateException.class);
+
+            builder.annotation(Curator.class).path("/dev/test").build();
+        }
+
+        @Test
+        public void build_WithMapperAndAnnotationAndNoPathSet_ThrowsISE() {
+            thrown.expect(IllegalStateException.class);
+
+            builder.mapper(StringUTF8ByteArrayMapper.class).annotation(Names.named("test")).build();
+        }
+
+        @Test
+        public void build_WithMapperAndPathSetAndNoAnnotation_ThrowsISE() {
+            thrown.expect(IllegalStateException.class);
+
+            builder.mapper(StringUTF8ByteArrayMapper.class).path("test").build();
+        }
+
+        @Test
+        public void build_WithMapperAndPathAndAnnotationClass_NotNull() {
+            assertNotNull(builder.mapper(StringUTF8ByteArrayMapper.class).path("/dev/test").annotation(Curator.class)
+                    .build());
+        }
+
+        @Test
+        public void build_WithMapperAndPathAndAnnotation_NotNull() {
+            assertNotNull(builder.mapper(StringUTF8ByteArrayMapper.class).path("/dev/test")
+                    .annotation(Names.named("test")).build());
+        }
+
+        @Test
+        public void createInjector_WithoutCuratorFramework_ThrowsCreationException() {
+            thrown.expect(CreationException.class);
+
+            Guice.createInjector(builder.mapper(StringUTF8ByteArrayMapper.class).path("/dev/test")
+                    .annotation(Names.named("test")).build());
+        }
+    }
+
+    @RunWith(MockitoJUnitRunner.class)
+    public static class InjectorTest {
+        @Mock
+        private EnsurePath ensurePath;
+
+        @Mock
+        private CuratorFramework framework;
+
+        private Injector injector;
+
+        @Before
+        public void setUp() {
+            when(framework.newNamespaceAwareEnsurePath(anyString())).thenReturn(ensurePath);
+
+            Module module = NodeContainerModuleBuilder.create(String.class).annotation(Curator.class)
+                    .mapper(StringUTF8ByteArrayMapper.class).path("dev/test").build();
+            injector = Guice.createInjector(Stage.PRODUCTION, new AbstractModule() {
+                @Override
+                protected void configure() {
+                    bind(CuratorFramework.class).annotatedWith(Curator.class).toInstance(framework);
+                }
+            }, module);
+        }
+
+        @Test
+        public void getInstance_NodeContainerWithAnnotation_ReturnsNodeContainer() {
+            assertNotNull(injector.getInstance(Key.get(Types.newParameterizedType(NodeContainer.class, String.class),
+                    Curator.class)));
+        }
+
+        @Test
+        public void getExistingBinding_NodeContainerWithAnnotation_IsSingleton() {
+            assertTrue(Scopes.isSingleton(injector.getExistingBinding(Key.get(
+                    Types.newParameterizedType(NodeContainer.class, String.class), Curator.class))));
+        }
+
+        @Test
+        public void getInstance_SetOfCuratorServices_IncludesNodeContainer() {
+            for (CuratorService o : injector.getInstance(Key.get(new TypeLiteral<Set<CuratorService>>() {
+            }))) {
+                if (o instanceof NodeContainer) {
+                    return;
+                }
+            }
+
+            fail("NodeContainer not in set of CuratorServices");
+        }
+    }
+}

--- a/cultivar-core/src/test/java/com/readytalk/cultivar/util/mapping/AbstractByteArrayMapperTest.java
+++ b/cultivar-core/src/test/java/com/readytalk/cultivar/util/mapping/AbstractByteArrayMapperTest.java
@@ -1,0 +1,45 @@
+package com.readytalk.cultivar.util.mapping;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.base.Charsets;
+
+public class AbstractByteArrayMapperTest {
+
+    private final Object returnObject = new Object();
+
+    private AbstractByteArrayMapper<Object> mapper;
+
+    @Before
+    public void setUp() throws Exception {
+        mapper = new AbstractByteArrayMapper<Object>() {
+            @Override
+            public Object map(final byte[] bytes) {
+                checkNotNull(bytes);
+                return returnObject;
+            }
+        };
+    }
+
+    @Test
+    public void map_NonNullParameter_WithNoDefault_ReturnObject() {
+        assertEquals(returnObject, mapper.map("foo".getBytes(Charsets.UTF_8)));
+    }
+
+    @Test
+    public void map_NullParameter_WithDefault_ReturnsDefault() {
+
+        String value = "foo";
+        assertEquals(value, mapper.map(null, value));
+    }
+
+    @Test
+    public void map_NonNullParameter_WithDefault_ReturnObject() {
+        String value = "foo";
+        assertEquals(returnObject, mapper.map(value.getBytes(Charsets.UTF_8), value));
+    }
+}

--- a/cultivar-core/src/test/java/com/readytalk/cultivar/util/mapping/BooleanUTF8ByteArrayMapperTest.java
+++ b/cultivar-core/src/test/java/com/readytalk/cultivar/util/mapping/BooleanUTF8ByteArrayMapperTest.java
@@ -1,0 +1,46 @@
+package com.readytalk.cultivar.util.mapping;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.google.common.base.Charsets;
+
+@SuppressWarnings("ConstantConditions")
+public class BooleanUTF8ByteArrayMapperTest {
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    private BooleanUTF8ByteArrayMapper mapper;
+
+    @Before
+    public void setUp() throws Exception {
+        mapper = new BooleanUTF8ByteArrayMapper();
+    }
+
+    @Test
+    public void map_Null_ThrowsNPE() {
+        thrown.expect(NullPointerException.class);
+
+        mapper.map(null);
+    }
+
+    @Test
+    public void map_WithTrueUTF8String_ReturnsTrue() {
+        assertTrue(mapper.map("true".getBytes(Charsets.UTF_8)));
+    }
+
+    @Test
+    public void map_WithFalseUTF8String_ReturnsFalse() {
+        assertFalse(mapper.map("false".getBytes(Charsets.UTF_8)));
+    }
+
+    @Test
+    public void map_WithUnknownUTF8String_ReturnsFalse() {
+        assertFalse(mapper.map("1".getBytes(Charsets.UTF_8)));
+    }
+}

--- a/cultivar-core/src/test/java/com/readytalk/cultivar/util/mapping/NOPByteArrayMapperTest.java
+++ b/cultivar-core/src/test/java/com/readytalk/cultivar/util/mapping/NOPByteArrayMapperTest.java
@@ -1,0 +1,36 @@
+package com.readytalk.cultivar.util.mapping;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+@SuppressWarnings("ConstantConditions")
+public class NOPByteArrayMapperTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    private NOPByteArrayMapper mapper;
+
+    @Before
+    public void setUp() {
+        mapper = new NOPByteArrayMapper();
+    }
+
+    @Test
+    public void map_WithByteArray_ReturnsSelf() {
+        byte[] bytes = new byte[] { 0x01, 0x02 };
+
+        assertArrayEquals(bytes, mapper.map(bytes));
+    }
+
+    @Test
+    public void map_Null_ThrowsNPE() {
+        thrown.expect(NullPointerException.class);
+
+        mapper.map(null);
+    }
+}

--- a/cultivar-core/src/test/java/com/readytalk/cultivar/util/mapping/StringUTF8ByteArrayMapperTest.java
+++ b/cultivar-core/src/test/java/com/readytalk/cultivar/util/mapping/StringUTF8ByteArrayMapperTest.java
@@ -1,0 +1,37 @@
+package com.readytalk.cultivar.util.mapping;
+
+import com.google.common.base.Charsets;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.*;
+
+@SuppressWarnings("ConstantConditions")
+public class StringUTF8ByteArrayMapperTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    private StringUTF8ByteArrayMapper mapper;
+
+    @Before
+    public void setUp() throws Exception {
+        mapper = new StringUTF8ByteArrayMapper();
+    }
+
+    @Test
+    public void map_Null_ThrowsNPE() {
+        thrown.expect(NullPointerException.class);
+
+        mapper.map(null);
+    }
+
+    @Test
+    public void map_String_ReturnsString() {
+        String value = "foo";
+
+        assertEquals(value, mapper.map(value.getBytes(Charsets.UTF_8)));
+    }
+}


### PR DESCRIPTION
- Added the ability to define individual node caches.
- Added mapper abstractions to convert the byte arrays to a more useful value.
