### PR TITLE
Adds simplified service registration. Addresses Issue #10.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,13 +5,14 @@ Changelog
 -----
 
 * Set license as Apache.
-* Build changes.
+* Build changes (Issue #11, Issue #25).
 
 1.3.0
 -----
 
-* Upgraded dependencies.
-* Added namespaces. 
+* Upgraded dependencies (Issue #25).
+* Added namespaces (Issue #31). 
 * Added CuratorUninterruptibles.
-* Parameterized AbstractZookeeperClusterTest.
+* Parameterized AbstractZookeeperClusterTest (Issue #23).
 * Minor documentation fixes.
+* Easier registration for discovery (Issue #10).

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/internal/BinderAssistant.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/internal/BinderAssistant.java
@@ -1,0 +1,61 @@
+package com.readytalk.cultivar.internal;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import javax.inject.Provider;
+
+import com.google.common.annotations.Beta;
+import com.google.inject.Binder;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import com.google.inject.util.Providers;
+
+@Beta
+public class BinderAssistant<T> {
+    private final Class<? extends Provider<? extends T>> providerClass;
+    private final Key<? extends Provider<? extends T>> providerKey;
+    private final Provider<? extends T> providerInstance;
+    private final TypeLiteral<? extends Provider<? extends T>> providerLiteral;
+
+    public BinderAssistant(final Class<? extends Provider<? extends T>> provider) {
+        this.providerClass = checkNotNull(provider);
+        this.providerKey = null;
+        this.providerInstance = null;
+        this.providerLiteral = null;
+    }
+
+    public BinderAssistant(final Key<? extends Provider<? extends T>> provider) {
+        this.providerClass = null;
+        this.providerKey = checkNotNull(provider);
+        this.providerInstance = null;
+        this.providerLiteral = null;
+    }
+
+    public BinderAssistant(final Provider<? extends T> provider) {
+        this.providerClass = null;
+        this.providerKey = null;
+        this.providerInstance = checkNotNull(provider);
+        this.providerLiteral = null;
+    }
+
+    public BinderAssistant(final TypeLiteral<? extends Provider<? extends T>> provider) {
+        this.providerClass = null;
+        this.providerKey = null;
+        this.providerInstance = null;
+        this.providerLiteral = checkNotNull(provider);
+    }
+
+    public void bindToProvider(final Binder binder, final Key<T> key) {
+
+        if (providerClass != null) {
+            binder.bind(key).toProvider(providerClass);
+        } else if (providerKey != null) {
+            binder.bind(key).toProvider(providerKey);
+        } else if (providerInstance != null) {
+            binder.bind(key).toProvider(Providers.guicify(providerInstance));
+        } else if (providerLiteral != null) {
+            binder.bind(key).toProvider(providerLiteral);
+        }
+    }
+
+}

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/internal/package-info.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/internal/package-info.java
@@ -1,5 +1,9 @@
 /**
- * Internal utilities for use with Cultivar. Should not be used by outside projects.
+ * Internal utilities for use with Cultivar. These may break or abuse more standard conventions found elsewhere and
+ * exist here because of some of the pecularities in how Guice or Java work with defining and constructing generic
+ * builders.
+ * 
+ * Should not be used by outside projects.
  */
 @javax.annotation.ParametersAreNonnullByDefault
 package com.readytalk.cultivar.internal;

--- a/cultivar-core/src/test/java/com/readytalk/cultivar/internal/BinderAssistantTest.java
+++ b/cultivar-core/src/test/java/com/readytalk/cultivar/internal/BinderAssistantTest.java
@@ -1,0 +1,79 @@
+package com.readytalk.cultivar.internal;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.readytalk.cultivar.internal.BinderAssistant;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.inject.Binder;
+import com.google.inject.Key;
+import com.google.inject.Provider;
+import com.google.inject.TypeLiteral;
+import com.google.inject.binder.LinkedBindingBuilder;
+import com.google.inject.util.Providers;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BinderAssistantTest {
+
+    public static class StringProvider implements Provider<Provider<String>> {
+        @Override
+        public Provider<String> get() {
+            return Providers.of("test");
+        }
+    }
+
+    private final Key<Provider<String>> key = Key.get(new TypeLiteral<Provider<String>>() {
+    });
+
+    @Mock
+    private Binder binder;
+
+    @Mock
+    private LinkedBindingBuilder<Provider<String>> bindingBuilder;
+
+    @Before
+    public void setUp() {
+        when(binder.bind(eq(key))).thenReturn(bindingBuilder);
+    }
+
+    @Test
+    public void bindToProvider_Class_Binds() {
+        new BinderAssistant<Provider<String>>(StringProvider.class).bindToProvider(binder, key);
+
+        verify(bindingBuilder).toProvider(StringProvider.class);
+    }
+
+    @Test
+    public void bindToProvider_Instance_Binds() {
+        Provider<Provider<String>> instance = new StringProvider();
+
+        new BinderAssistant<Provider<String>>(instance).bindToProvider(binder, key);
+
+        verify(bindingBuilder).toProvider(instance);
+    }
+
+    @Test
+    public void bindToProvider_TypeLiteral_Binds() {
+        TypeLiteral<Provider<Provider<String>>> typeLiteral = new TypeLiteral<Provider<Provider<String>>>() {
+        };
+
+        new BinderAssistant<Provider<String>>(typeLiteral).bindToProvider(binder, key);
+
+        verify(bindingBuilder).toProvider(typeLiteral);
+    }
+
+    @Test
+    public void bindToProvider_Key_Binds() {
+        Key<StringProvider> typeKey = Key.get(StringProvider.class);
+
+        new BinderAssistant<Provider<String>>(typeKey).bindToProvider(binder, key);
+
+        verify(bindingBuilder).toProvider(typeKey);
+    }
+}

--- a/cultivar-discovery/src/integTest/java/com/readytalk/cultivar/discovery/RegistrationIntegTest.java
+++ b/cultivar-discovery/src/integTest/java/com/readytalk/cultivar/discovery/RegistrationIntegTest.java
@@ -1,0 +1,136 @@
+package com.readytalk.cultivar.discovery;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.ensemble.EnsembleProvider;
+import org.apache.curator.ensemble.fixed.FixedEnsembleProvider;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.x.discovery.ServiceInstance;
+import org.apache.curator.x.discovery.ServiceProvider;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ServiceManager;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Names;
+import com.google.inject.util.Providers;
+import com.readytalk.cultivar.Cultivar;
+import com.readytalk.cultivar.CultivarStartStopManager;
+import com.readytalk.cultivar.Curator;
+import com.readytalk.cultivar.CuratorModule;
+import com.readytalk.cultivar.test.AbstractZookeeperClusterTest;
+import com.readytalk.cultivar.test.ConditionalWait;
+
+public class RegistrationIntegTest extends AbstractZookeeperClusterTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    private Injector inj;
+
+    private ServiceInstance<Void> service1;
+
+    private ServiceInstance<Void> service2;
+
+    private ServiceProvider<Void> provider;
+
+    private CultivarStartStopManager manager;
+
+    private ServiceManager registrationManager;
+
+    @Before
+    public void setUp() throws Exception {
+
+        service1 = ServiceInstance.<Void> builder().id(UUID.randomUUID().toString()).name("service").build();
+
+        service2 = ServiceInstance.<Void> builder().id(UUID.randomUUID().toString()).name("service").build();
+
+        inj = Guice.createInjector(
+                new AbstractModule() {
+                    @Override
+                    protected void configure() {
+                        bindConstant().annotatedWith(Names.named("Cultivar.Curator.baseNamespace")).to("dev/test");
+                    }
+                },
+                new CuratorModule(new AbstractModule() {
+                    @Override
+                    protected void configure() {
+                        bind(EnsembleProvider.class).annotatedWith(Curator.class).toInstance(
+                                new FixedEnsembleProvider(testingCluster.getConnectString()));
+                        bind(RetryPolicy.class).annotatedWith(Curator.class).toInstance(
+                                new ExponentialBackoffRetry(1000, 3));
+
+                    }
+                }),
+                new RegistrationModule(),
+                ServiceDiscoveryModuleBuilder.create().annotation(Curator.class).basePath("/discovery").build(),
+                ServiceProviderModuleBuilder.create(Void.class).name("service").discovery(Curator.class)
+                        .annotation(Cultivar.class).build(),
+                RegistrationServiceModuleBuilder.create().discoveryAnnotation(Curator.class)
+                        .targetAnnotation(Curator.class).provider(Providers.of(service1)).build(),
+                RegistrationServiceModuleBuilder
+                        .create()
+                        .discoveryAnnotation(Curator.class)
+                        .targetAnnotation(Cultivar.class)
+                        .provider(Providers.of(service2))
+                        .updating(
+                                10,
+                                TimeUnit.SECONDS,
+                                MoreExecutors.getExitingScheduledExecutorService(new ScheduledThreadPoolExecutor(1),
+                                        10, TimeUnit.MILLISECONDS)).build());
+
+        registrationManager = inj.getInstance(Key.get(ServiceManager.class, Discovery.class));
+
+        provider = inj.getInstance(Key.get(new TypeLiteral<ServiceProvider<Void>>() {
+        }, Cultivar.class));
+
+        manager = inj.getInstance(CultivarStartStopManager.class);
+
+        manager.startAsync().awaitRunning();
+
+    }
+
+    private void awaitPopulation() throws Exception {
+        new ConditionalWait(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return provider.getAllInstances().size() > 1;
+            }
+        }).await();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        try {
+            registrationManager.stopAsync().awaitStopped();
+        } finally {
+
+            inj.getInstance(CultivarStartStopManager.class).stopAsync().awaitTerminated();
+        }
+    }
+
+    @Test
+    public void provider_bothInstancesPopulated() throws Exception {
+        registrationManager.startAsync().awaitHealthy();
+
+        awaitPopulation();
+
+        assertEquals(2, provider.getAllInstances().size());
+    }
+}

--- a/cultivar-discovery/src/main/java/com/readytalk/cultivar/discovery/DefaultRegistrationService.java
+++ b/cultivar-discovery/src/main/java/com/readytalk/cultivar/discovery/DefaultRegistrationService.java
@@ -1,0 +1,57 @@
+package com.readytalk.cultivar.discovery;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verifyNotNull;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.curator.x.discovery.ServiceDiscovery;
+import org.apache.curator.x.discovery.ServiceInstance;
+
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.common.util.concurrent.Atomics;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.readytalk.cultivar.internal.Private;
+
+/**
+ * A simple registration service that registers and unregisters an instance coming from a provider.
+ * 
+ * @param <T>
+ *            The payload type for discovery.
+ */
+class DefaultRegistrationService<T> extends AbstractIdleService implements RegistrationService<T> {
+
+    private final ServiceDiscovery<T> discovery;
+    private final Provider<ServiceInstance<T>> provider;
+
+    private final AtomicReference<ServiceInstance<T>> instance = Atomics.newReference();
+
+    @Inject
+    DefaultRegistrationService(@Private final ServiceDiscovery<T> discovery,
+            @Private final Provider<ServiceInstance<T>> provider) {
+        this.discovery = discovery;
+        this.provider = provider;
+    }
+
+    @Override
+    protected void startUp() throws Exception {
+
+        ServiceInstance<T> service = provider.get();
+
+        checkState(service != null, "Null providers are not accepted.");
+
+        instance.set(provider.get());
+
+        discovery.registerService(instance.get());
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
+        ServiceInstance<T> service = instance.getAndSet(null);
+
+        verifyNotNull(service, "Service has not been set. Should never happen.");
+
+        discovery.unregisterService(service);
+    }
+}

--- a/cultivar-discovery/src/main/java/com/readytalk/cultivar/discovery/Discovery.java
+++ b/cultivar-discovery/src/main/java/com/readytalk/cultivar/discovery/Discovery.java
@@ -1,0 +1,23 @@
+package com.readytalk.cultivar.discovery;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+import com.google.common.annotations.Beta;
+
+/**
+ * Marker annotation for discovery-based instantiation.
+ */
+@Qualifier
+@Target({ FIELD, PARAMETER, METHOD })
+@Retention(RUNTIME)
+@Beta
+public @interface Discovery {
+}

--- a/cultivar-discovery/src/main/java/com/readytalk/cultivar/discovery/RegistrationModule.java
+++ b/cultivar-discovery/src/main/java/com/readytalk/cultivar/discovery/RegistrationModule.java
@@ -1,0 +1,28 @@
+package com.readytalk.cultivar.discovery;
+
+import java.util.Set;
+
+import com.google.common.annotations.Beta;
+import com.google.common.util.concurrent.ServiceManager;
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.google.inject.TypeLiteral;
+import com.google.inject.multibindings.Multibinder;
+
+@Beta
+public class RegistrationModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        Multibinder.newSetBinder(binder(), new TypeLiteral<RegistrationService<?>>() {
+        });
+    }
+
+    @Provides
+    @Discovery
+    @Singleton
+    public ServiceManager manager(final Set<RegistrationService<?>> registrationServices) {
+        return new ServiceManager(registrationServices);
+    }
+}

--- a/cultivar-discovery/src/main/java/com/readytalk/cultivar/discovery/RegistrationService.java
+++ b/cultivar-discovery/src/main/java/com/readytalk/cultivar/discovery/RegistrationService.java
@@ -1,0 +1,7 @@
+package com.readytalk.cultivar.discovery;
+
+/**
+ * Registers a service with discovery. Typed to represent the different payloads.
+ */
+public interface RegistrationService<T> extends DiscoveryService {
+}

--- a/cultivar-discovery/src/main/java/com/readytalk/cultivar/discovery/RegistrationServiceModuleBuilder.java
+++ b/cultivar-discovery/src/main/java/com/readytalk/cultivar/discovery/RegistrationServiceModuleBuilder.java
@@ -1,0 +1,241 @@
+package com.readytalk.cultivar.discovery;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import java.lang.annotation.Annotation;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nonnegative;
+import javax.inject.Provider;
+
+import org.apache.curator.x.discovery.ServiceDiscovery;
+import org.apache.curator.x.discovery.ServiceInstance;
+
+import com.google.common.annotations.Beta;
+import com.google.common.util.concurrent.AbstractScheduledService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.inject.AbstractModule;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.PrivateModule;
+import com.google.inject.Scopes;
+import com.google.inject.TypeLiteral;
+import com.google.inject.multibindings.Multibinder;
+import com.google.inject.util.Types;
+import com.readytalk.cultivar.internal.AnnotationHolder;
+import com.readytalk.cultivar.internal.BinderAssistant;
+import com.readytalk.cultivar.internal.Private;
+
+/**
+ *
+ * Constructs a service that registers itself when started with discovery. This is similar to using the Curator built-in
+ * instance registration, with a few tweaks:
+ * 
+ * <ul>
+ * <li>Allows/encourages the rest of the system to finish starting up before registration takes place.</li>
+ * <li>Allows/encourages deregistration before the rest of the system has been torn down.</li>
+ * <li>Allows for the slightly more complex scenario of self-updating instances.</li>
+ * <li>Facilitates the use-case where one service may register multiple discovery endpoints.</li>
+ * </ul>
+ *
+ * @param <T>
+ *            The type of the Service Discovery system.
+ */
+@Beta
+public class RegistrationServiceModuleBuilder<T> {
+
+    private final Class<T> clazz;
+
+    private AnnotationHolder discoveryHolder = null;
+
+    private AnnotationHolder targetHolder = null;
+
+    private BinderAssistant<ServiceInstance<T>> binderAssistant;
+
+    private AbstractScheduledService.Scheduler scheduler = null;
+
+    private ScheduledExecutorService executorService = null;
+
+    private Class<? extends RegistrationService> bindType = DefaultRegistrationService.class;
+
+    RegistrationServiceModuleBuilder(final Class<T> clazz) {
+        this.clazz = clazz;
+    }
+
+    /**
+     * Creates a RegistrationServiceModuleBuilder of Void type.
+     */
+    public static RegistrationServiceModuleBuilder<Void> create() {
+        return create(Void.class);
+    }
+
+    /**
+     * Creates a RegistrationServiceModuleBuilder.
+     */
+    public static <T> RegistrationServiceModuleBuilder<T> create(final Class<T> clazz) {
+        return new RegistrationServiceModuleBuilder<T>(clazz);
+    }
+
+    /**
+     * The annotation to put the RegistrationService under.
+     */
+    public RegistrationServiceModuleBuilder<T> targetAnnotation(final Annotation annotation) {
+
+        targetHolder = AnnotationHolder.create(annotation);
+
+        return this;
+    }
+
+    /**
+     * The annotation to put the RegistrationService under.
+     */
+    public RegistrationServiceModuleBuilder<T> targetAnnotation(final Class<? extends Annotation> annotation) {
+
+        targetHolder = AnnotationHolder.create(annotation);
+
+        return this;
+    }
+
+    /**
+     * The annotation to look up the DiscoveryService under.
+     */
+    public RegistrationServiceModuleBuilder<T> discoveryAnnotation(final Annotation annotation) {
+
+        discoveryHolder = AnnotationHolder.create(annotation);
+
+        return this;
+    }
+
+    /**
+     * The annotation to put the RegistrationService under.
+     */
+    public RegistrationServiceModuleBuilder<T> discoveryAnnotation(final Class<? extends Annotation> annotation) {
+
+        discoveryHolder = AnnotationHolder.create(annotation);
+
+        return this;
+    }
+
+    /**
+     * Reference to the provider for the ServiceInstance to use. This should be a consistent instance between calls,
+     * though it is allowed to change.
+     */
+    public RegistrationServiceModuleBuilder<T> provider(
+            final Class<? extends Provider<ServiceInstance<T>>> instanceProvider) {
+
+        binderAssistant = new BinderAssistant<ServiceInstance<T>>(instanceProvider);
+
+        return this;
+    }
+
+    public RegistrationServiceModuleBuilder<T> provider(
+            final Key<? extends Provider<ServiceInstance<T>>> instanceProvider) {
+
+        binderAssistant = new BinderAssistant<ServiceInstance<T>>(instanceProvider);
+
+        return this;
+    }
+
+    public RegistrationServiceModuleBuilder<T> provider(final Provider<? extends ServiceInstance<T>> instanceProvider) {
+
+        binderAssistant = new BinderAssistant<ServiceInstance<T>>(instanceProvider);
+
+        return this;
+    }
+
+    public RegistrationServiceModuleBuilder<T> provider(
+            final TypeLiteral<? extends Provider<ServiceInstance<T>>> instanceProvider) {
+
+        binderAssistant = new BinderAssistant<ServiceInstance<T>>(instanceProvider);
+
+        return this;
+    }
+
+    public RegistrationServiceModuleBuilder<T> updating(@Nonnegative final long time, final TimeUnit unit) {
+        return this.updating(time, unit,
+                MoreExecutors.getExitingScheduledExecutorService(new ScheduledThreadPoolExecutor(1)));
+    }
+
+    /**
+     * Set the bound instance to update from the provider at a certain delay.
+     * 
+     * @param time
+     *            The amount of time to spend before the first registration and between registrations.
+     * @param unit
+     *            The time unit for time.
+     * @param service
+     *            An optional ScheduledExecutorService. By default this will be an exitingScheduledExecutorService with
+     *            default parameters.
+     */
+    public RegistrationServiceModuleBuilder<T> updating(@Nonnegative final long time, final TimeUnit unit,
+            final ScheduledExecutorService service) {
+        checkArgument(time > 0, "Time must be positive.");
+        checkNotNull(unit, "TimeUnit must not be null.");
+        checkNotNull(service, "Provided executor service must not be null.");
+
+        scheduler = AbstractScheduledService.Scheduler.newFixedDelaySchedule(time, time, unit);
+
+        executorService = service;
+
+        bindType = UpdatingRegistrationService.class;
+
+        return this;
+    }
+
+    public Module build() {
+        checkState(targetHolder != null, "Target annotation has not been set.");
+        checkState(discoveryHolder != null, "Discovery annotation has not been set.");
+        checkState(binderAssistant != null, "No provider provided.");
+
+        return new AbstractModule() {
+            @SuppressWarnings("unchecked")
+            @Override
+            protected void configure() {
+                final Key<RegistrationService<T>> registrationServiceKey = (Key<RegistrationService<T>>) targetHolder
+                        .generateKey(Types.newParameterizedType(RegistrationService.class, clazz));
+
+                install(new PrivateModule() {
+                    @SuppressWarnings("unchecked")
+                    @Override
+                    protected void configure() {
+
+                        if (scheduler != null) {
+                            bind(AbstractScheduledService.Scheduler.class).annotatedWith(Private.class).toInstance(
+                                    scheduler);
+                            bind(ScheduledExecutorService.class).annotatedWith(Private.class).toInstance(
+                                    executorService);
+                        }
+
+                        bind(
+                                (Key<ServiceDiscovery<T>>) Key.get(
+                                        Types.newParameterizedType(ServiceDiscovery.class, clazz), Private.class)).to(
+                                (Key<ServiceDiscovery<T>>) discoveryHolder.generateKey(Types.newParameterizedType(
+                                        ServiceDiscovery.class, clazz)));
+
+                        binderAssistant.bindToProvider(
+                                binder(),
+                                (Key<ServiceInstance<T>>) Key.get(
+                                        Types.newParameterizedType(ServiceInstance.class, clazz), Private.class));
+
+                        bind(registrationServiceKey).to(
+                                (Key<? extends RegistrationService<T>>) Key.get(Types.newParameterizedType(bindType,
+                                        clazz))).in(Scopes.SINGLETON);
+
+                        expose(registrationServiceKey);
+                    }
+                });
+
+                Multibinder<RegistrationService<?>> services = Multibinder.newSetBinder(binder(),
+                        new TypeLiteral<RegistrationService<?>>() {
+                        });
+
+                services.addBinding().to(registrationServiceKey);
+
+            }
+        };
+    }
+}

--- a/cultivar-discovery/src/main/java/com/readytalk/cultivar/discovery/UpdatingRegistrationService.java
+++ b/cultivar-discovery/src/main/java/com/readytalk/cultivar/discovery/UpdatingRegistrationService.java
@@ -1,0 +1,94 @@
+package com.readytalk.cultivar.discovery;
+
+import static com.google.common.base.Verify.verifyNotNull;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.apache.curator.x.discovery.ServiceDiscovery;
+import org.apache.curator.x.discovery.ServiceInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.Beta;
+import com.google.common.util.concurrent.AbstractScheduledService;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.readytalk.cultivar.internal.Private;
+
+/**
+ * A version of the RegistrationService that updates based on a provider on a regular schedule. If there is ane
+ * exception coming from the discovery system it will log it, and if it is an InterruptedException it will interrupt the
+ * thread.
+ *
+ * @param <T>
+ *            The type of payload for discovery.
+ */
+@Beta
+class UpdatingRegistrationService<T> extends AbstractScheduledService implements RegistrationService<T> {
+
+    private final Logger log;
+
+    private final ServiceDiscovery<T> discovery;
+    private final Provider<ServiceInstance<T>> provider;
+
+    private final Scheduler scheduler;
+    private final ScheduledExecutorService executorService;
+
+    @Inject
+    UpdatingRegistrationService(@Private final ServiceDiscovery<T> discovery,
+            @Private final Provider<ServiceInstance<T>> provider, @Private final Scheduler scheduler,
+            @Private final ScheduledExecutorService executorService) {
+        this(discovery, provider, scheduler, executorService, LoggerFactory
+                .getLogger(UpdatingRegistrationService.class));
+    }
+
+    UpdatingRegistrationService(@Private final ServiceDiscovery<T> discovery,
+            @Private final Provider<ServiceInstance<T>> provider, @Private final Scheduler scheduler,
+            @Private final ScheduledExecutorService executorService, final Logger log) {
+        this.discovery = discovery;
+        this.provider = provider;
+
+        this.scheduler = scheduler;
+
+        this.executorService = executorService;
+
+        this.log = log;
+    }
+
+    @Override
+    protected void startUp() throws Exception {
+
+        discovery.registerService(verifyNotNull(provider.get(), "Provider should not return null."));
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
+        discovery.unregisterService(provider.get());
+    }
+
+    @Override
+    protected Scheduler scheduler() {
+        return scheduler;
+    }
+
+    @Override
+    protected void runOneIteration() throws Exception {
+
+        ServiceInstance<T> instance = null;
+        try {
+            instance = verifyNotNull(provider.get());
+
+            discovery.updateService(instance);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted for service: " + String.valueOf(instance), ex);
+        } catch (Exception ex) {
+            log.warn("Exception while updating service: " + String.valueOf(instance), ex);
+        }
+    }
+
+    @Override
+    protected ScheduledExecutorService executor() {
+        return this.executorService;
+    }
+}

--- a/cultivar-discovery/src/test/java/com/readytalk/cultivar/discovery/DefaultRegistrationServiceTest.java
+++ b/cultivar-discovery/src/test/java/com/readytalk/cultivar/discovery/DefaultRegistrationServiceTest.java
@@ -1,0 +1,65 @@
+package com.readytalk.cultivar.discovery;
+
+import static org.mockito.Mockito.verify;
+
+import org.apache.curator.x.discovery.ServiceDiscovery;
+import org.apache.curator.x.discovery.ServiceInstance;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.common.base.VerifyException;
+import com.google.inject.util.Providers;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultRegistrationServiceTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    @Mock
+    private ServiceInstance<Void> instance;
+
+    @Mock
+    private ServiceDiscovery<Void> discovery;
+
+    private DefaultRegistrationService<Void> discoveryRegistration;
+
+    @Before
+    public void setUp() {
+        discoveryRegistration = new DefaultRegistrationService<Void>(discovery, Providers.of(instance));
+    }
+
+    @Test
+    public void startUp_RegistersService() throws Exception {
+        discoveryRegistration.startUp();
+        verify(discovery).registerService(instance);
+    }
+
+    @Test
+    public void startUp_NullProvider_ThrowsISE() throws Exception {
+        thrown.expect(IllegalStateException.class);
+
+        new DefaultRegistrationService<Void>(discovery, Providers.<ServiceInstance<Void>> of(null)).startUp();
+    }
+
+    @Test
+    public void shutDown_AfterStartUp_UnregistersService() throws Exception {
+        discoveryRegistration.startUp();
+
+        discoveryRegistration.shutDown();
+
+        verify(discovery).unregisterService(instance);
+    }
+
+    @Test
+    public void shutDown_WithoutStartup_ThrowsVerifyException() throws Exception {
+        thrown.expect(VerifyException.class);
+
+        discoveryRegistration.shutDown();
+    }
+}

--- a/cultivar-discovery/src/test/java/com/readytalk/cultivar/discovery/RegistrationServiceModuleBuilderTest.java
+++ b/cultivar-discovery/src/test/java/com/readytalk/cultivar/discovery/RegistrationServiceModuleBuilderTest.java
@@ -1,0 +1,200 @@
+package com.readytalk.cultivar.discovery;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Provider;
+
+import org.apache.curator.x.discovery.ServiceDiscovery;
+import org.apache.curator.x.discovery.ServiceInstance;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.common.base.Throwables;
+import com.google.inject.AbstractModule;
+import com.google.inject.CreationException;
+import com.google.inject.Guice;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.Stage;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Names;
+import com.google.inject.util.Types;
+import com.readytalk.cultivar.Cultivar;
+
+@RunWith(Enclosed.class)
+@SuppressWarnings("unchecked")
+public class RegistrationServiceModuleBuilderTest {
+    public static final ServiceInstance<Void> INSTANCE = generateInstance();
+
+    private static ServiceInstance<Void> generateInstance() {
+        try {
+            return ServiceInstance.<Void> builder().address("localhost").name("foo").build();
+        } catch (Exception ex) {
+            throw Throwables.propagate(ex);
+        }
+    }
+
+    public static class BuilderTest {
+
+        public static class ServiceInstanceProvider implements Provider<ServiceInstance<Void>> {
+            @Override
+            public ServiceInstance<Void> get() {
+                return INSTANCE;
+            }
+        }
+
+        @Rule
+        public final ExpectedException thrown = ExpectedException.none();
+
+        @Test
+        public void updating_ZeroTime_ThrowsIAE() {
+            thrown.expect(IllegalArgumentException.class);
+
+            RegistrationServiceModuleBuilder.create().updating(0, TimeUnit.SECONDS);
+
+        }
+
+        @Test
+        public void build_DiscoveryNotSet_ThrowsISE() {
+            thrown.expect(IllegalStateException.class);
+
+            RegistrationServiceModuleBuilder.create().provider(ServiceInstanceProvider.class)
+                    .targetAnnotation(Cultivar.class).build();
+
+        }
+
+        @Test
+        public void build_TargetNotSet_ThrowsISE() {
+            thrown.expect(IllegalStateException.class);
+
+            RegistrationServiceModuleBuilder.create().provider(ServiceInstanceProvider.class)
+                    .discoveryAnnotation(Cultivar.class).build();
+
+        }
+
+        @Test
+        public void build_ProviderNotSet_ThrowsISE() {
+            thrown.expect(IllegalStateException.class);
+
+            RegistrationServiceModuleBuilder.create().targetAnnotation(Names.named("target"))
+                    .discoveryAnnotation(Names.named("discovery")).build();
+
+        }
+
+        @Test
+        public void build_AllValuesSetWithProviderInstance_ReturnsNotNull() {
+            assertNotNull(RegistrationServiceModuleBuilder.create().targetAnnotation(Names.named("target"))
+                    .discoveryAnnotation(Names.named("discovery")).provider(new ServiceInstanceProvider()).build());
+
+        }
+
+        @Test
+        public void build_AllValuesSetWithProviderKey_ReturnsNotNull() {
+            assertNotNull(RegistrationServiceModuleBuilder.create().targetAnnotation(Names.named("target"))
+                    .discoveryAnnotation(Names.named("discovery")).provider(Key.get(ServiceInstanceProvider.class))
+                    .build());
+
+        }
+
+        @Test
+        public void build_AllValuesSetWithProviderTypeLiteral_ReturnsNotNull() {
+            assertNotNull(RegistrationServiceModuleBuilder.create().targetAnnotation(Names.named("target"))
+                    .discoveryAnnotation(Names.named("discovery")).provider(new TypeLiteral<ServiceInstanceProvider>() {
+                    }).build());
+
+        }
+
+    }
+
+    @RunWith(MockitoJUnitRunner.class)
+    public static class ModuleTest {
+
+        public static class ServiceInstanceProvider implements Provider<ServiceInstance<Void>> {
+            @Override
+            public ServiceInstance<Void> get() {
+                return INSTANCE;
+            }
+        }
+
+        @Rule
+        public final ExpectedException thrown = ExpectedException.none();
+
+        @Mock
+        private ServiceDiscovery<Void> discovery;
+
+        private Module module;
+
+        @Before
+        public void setUp() {
+            module = RegistrationServiceModuleBuilder.create().targetAnnotation(Cultivar.class)
+                    .discoveryAnnotation(Cultivar.class).provider(new ServiceInstanceProvider()).build();
+        }
+
+        @Test
+        public void createInjector_NoDiscoveryDefined_ThrowsCreationException() {
+            thrown.expect(CreationException.class);
+
+            Guice.createInjector(module);
+        }
+
+        @Test
+        public void createInjector_DiscoveryDefined_ReturnsNotNull() {
+
+            assertNotNull(Guice.createInjector(Stage.PRODUCTION, module, new AbstractModule() {
+                @Override
+                protected void configure() {
+                    bind(
+                            (Key<ServiceDiscovery<Void>>) Key.get(
+                                    Types.newParameterizedType(ServiceDiscovery.class, Void.class), Cultivar.class))
+                            .toInstance(discovery);
+                }
+            }));
+        }
+
+        @Test
+        public void createInjector_DiscoveryDefinedAndScheduleDefinedWithExecutor_ReturnsNotNull() {
+
+            assertNotNull(Guice.createInjector(
+                    RegistrationServiceModuleBuilder.create().targetAnnotation(Cultivar.class)
+                            .discoveryAnnotation(Cultivar.class).provider(new ServiceInstanceProvider())
+                            .updating(10, TimeUnit.SECONDS, new ScheduledThreadPoolExecutor(1)).build(),
+                    new AbstractModule() {
+                        @Override
+                        protected void configure() {
+                            bind(
+                                    (Key<ServiceDiscovery<Void>>) Key.get(
+                                            Types.newParameterizedType(ServiceDiscovery.class, Void.class),
+                                            Cultivar.class)).toInstance(discovery);
+                        }
+                    }));
+        }
+
+        @Test
+        public void createInjector_DiscoveryDefinedAndScheduleDefinedSansExecutor_ReturnsNotNull() {
+
+            assertNotNull(Guice.createInjector(
+                    RegistrationServiceModuleBuilder.create().targetAnnotation(Cultivar.class)
+                            .discoveryAnnotation(Cultivar.class).provider(new ServiceInstanceProvider())
+                            .updating(10, TimeUnit.SECONDS).build(), new AbstractModule() {
+                        @Override
+                        protected void configure() {
+                            bind(
+                                    (Key<ServiceDiscovery<Void>>) Key.get(
+                                            Types.newParameterizedType(ServiceDiscovery.class, Void.class),
+                                            Cultivar.class)).toInstance(discovery);
+                        }
+                    }));
+        }
+
+    }
+
+}

--- a/cultivar-discovery/src/test/java/com/readytalk/cultivar/discovery/UpdatingRegistrationServiceTest.java
+++ b/cultivar-discovery/src/test/java/com/readytalk/cultivar/discovery/UpdatingRegistrationServiceTest.java
@@ -1,0 +1,123 @@
+package com.readytalk.cultivar.discovery;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.apache.curator.x.discovery.ServiceDiscovery;
+import org.apache.curator.x.discovery.ServiceInstance;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.Logger;
+
+import com.google.common.base.VerifyException;
+import com.google.common.util.concurrent.AbstractScheduledService;
+import com.google.inject.util.Providers;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UpdatingRegistrationServiceTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    @Mock
+    private ServiceDiscovery<Void> discovery;
+
+    @Mock
+    private ServiceInstance<Void> instance;
+
+    @Mock
+    private AbstractScheduledService.Scheduler scheduler;
+
+    @Mock
+    private ScheduledExecutorService executorService;
+
+    @Mock
+    private Logger log;
+
+    private UpdatingRegistrationService<Void> service;
+
+    @Before
+    public void setUp() {
+        service = new UpdatingRegistrationService<Void>(discovery, Providers.of(instance), scheduler, executorService,
+                log);
+    }
+
+    @After
+    public void tearDown() {
+        try {
+            Thread.sleep(1);
+        } catch (InterruptedException ex) {
+            // Clearing interrupt.
+        }
+    }
+
+    @Test
+    public void startUp_Instance_RegistersWithDiscovery() throws Exception {
+        service.startUp();
+
+        verify(discovery).registerService(instance);
+    }
+
+    @Test
+    public void startUp_Null_ThrowsVerifyException() throws Exception {
+        thrown.expect(VerifyException.class);
+
+        new UpdatingRegistrationService<Void>(discovery, Providers.<ServiceInstance<Void>> of(null), scheduler,
+                executorService, log).startUp();
+    }
+
+    @Test
+    public void scheduler_IsSameAsConstructor() {
+        assertEquals(scheduler, service.scheduler());
+    }
+
+    @Test
+    public void executor_IsSameAsConstructor() {
+        assertEquals(executorService, service.executor());
+    }
+
+    @Test
+    public void runOneIteration_NoExceptions_UpdatesDiscovery() throws Exception {
+        service.runOneIteration();
+
+        verify(discovery).updateService(instance);
+    }
+
+    @Test
+    public void runOneIteration_ExceptionInDiscovery_LogsException() throws Exception {
+        doThrow(Exception.class).when(discovery).updateService(instance);
+
+        service.runOneIteration();
+
+        verify(log).warn(anyString(), any(Exception.class));
+    }
+
+    @Test
+    public void runOneIteration_InterruptedExceptionInDiscovery_SetsInterruptFlag() throws Exception {
+        doThrow(InterruptedException.class).when(discovery).updateService(instance);
+
+        service.runOneIteration();
+
+        assertTrue(Thread.currentThread().isInterrupted());
+    }
+
+    @Test
+    public void runOneIteration_NullFromProvider_LogsVerifyException() throws Exception {
+        new UpdatingRegistrationService<Void>(discovery, Providers.<ServiceInstance<Void>> of(null), scheduler,
+                executorService, log).runOneIteration();
+
+        verify(log).warn(anyString(), any(VerifyException.class));
+    }
+}


### PR DESCRIPTION
Adds straightforward utilities for registering and unregistering services.   Significantly more flexible than `thisInstance` in Curator, but requires a little more up-front work to configure. Issue #10. 
