### PR TITLE
Simplified deregistration and Cultivar shut down. 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,3 +16,6 @@ Changelog
 * Parameterized AbstractZookeeperClusterTest (Issue #23).
 * Minor documentation fixes.
 * Easier registration for discovery (Issue #10).
+* Improved logging.
+* Improved documentation.
+* Easier unregistration/shutdown using either `java.lang.Runtime` shutdown hooks or customized shutdown systems (Issue #20).

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/CuratorModule.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/CuratorModule.java
@@ -67,6 +67,8 @@ public class CuratorModule extends AbstractModule {
 
         Multibinder.newSetBinder(binder(), CuratorListener.class);
 
+        Multibinder.newSetBinder(binder(), ServiceManager.class, Cultivar.class);
+
         Multibinder<ConnectionStateListener> connectionStateListeners = Multibinder.newSetBinder(binder(),
                 ConnectionStateListener.class);
 

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/DefaultCultivarStartStopManager.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/DefaultCultivarStartStopManager.java
@@ -1,15 +1,19 @@
 package com.readytalk.cultivar;
 
+import java.util.Set;
+
 import javax.annotation.concurrent.ThreadSafe;
-import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Throwables;
+import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.common.util.concurrent.ServiceManager;
+import com.google.inject.Inject;
+import com.readytalk.cultivar.management.ShutdownManager;
 
 @ThreadSafe
 @Beta
@@ -19,17 +23,29 @@ class DefaultCultivarStartStopManager extends AbstractIdleService implements Cul
 
     private final CuratorManagementService curatorManagementService;
     private final ServiceManager serviceManager;
+    private final Set<ServiceManager> additionalManagers;
+
+    private volatile ShutdownManager manager = null;
 
     @Inject
     DefaultCultivarStartStopManager(@Curator final CuratorManagementService curatorManagementService,
-            @Cultivar final ServiceManager serviceManager) {
+            @Cultivar final ServiceManager serviceManager, @Cultivar final Set<ServiceManager> additionalManagers) {
         this.curatorManagementService = curatorManagementService;
         this.serviceManager = serviceManager;
+        this.additionalManagers = additionalManagers;
 
+    }
+
+    @Inject(optional = true)
+    public void setShutdownManager(final ShutdownManager shutdownManager) {
+        this.manager = shutdownManager;
     }
 
     @Override
     protected void startUp() throws Exception {
+
+        LOG.debug("Starting up management service {}", curatorManagementService);
+
         try {
             curatorManagementService.startAsync().awaitRunning();
         } catch (IllegalStateException ex) {
@@ -45,17 +61,65 @@ class DefaultCultivarStartStopManager extends AbstractIdleService implements Cul
             throw Throwables.propagate(cause);
         }
 
+        LOG.debug("Starting up main ServiceManager {}", serviceManager);
+
         serviceManager.startAsync().awaitHealthy();
 
+        LOG.debug("Starting up plugin ServiceManagers {}", additionalManagers);
+
+        Set<ServiceManager> successes = Sets.newHashSet();
+
+        for (ServiceManager o : additionalManagers) {
+            try {
+                successes.add(o.startAsync());
+            } catch (IllegalStateException ex) {
+                LOG.warn("Exception with starting a ServiceManager {}", o, ex);
+            }
+        }
+
+        for (ServiceManager o : successes) {
+            try {
+                o.awaitHealthy();
+            } catch (IllegalStateException ex) {
+                LOG.warn("Exception in starting a service in ServiceManager {}", o, ex);
+            }
+        }
+
+        ShutdownHook.register(this, manager);
     }
 
     @Override
     protected void shutDown() throws Exception {
+
+        LOG.debug("Shutting down plugin ServiceManagers {}", additionalManagers);
+
+        Set<ServiceManager> successes = Sets.newHashSet();
+
+        for (ServiceManager o : additionalManagers) {
+            try {
+                successes.add(o.stopAsync());
+            } catch (IllegalStateException ex) {
+                LOG.warn("Exception with stopping a ServiceManager {}", o, ex);
+            }
+        }
+
+        for (ServiceManager o : successes) {
+            try {
+                o.awaitStopped();
+            } catch (IllegalStateException ex) {
+                LOG.warn("Exception in stopping a service in ServiceManager {}", o, ex);
+            }
+        }
+
+        LOG.debug("Shutting down main ServiceManager {}", serviceManager);
+
         try {
             serviceManager.stopAsync().awaitStopped();
         } catch (Exception ex) {
             LOG.warn("Exception when shutting down service manager", ex);
         }
+
+        LOG.debug("Shutting down management service {}", curatorManagementService);
 
         try {
             curatorManagementService.stopAsync().awaitTerminated();
@@ -70,5 +134,6 @@ class DefaultCultivarStartStopManager extends AbstractIdleService implements Cul
             Throwables.propagateIfPossible(cause, Exception.class);
             throw Throwables.propagate(cause);
         }
+
     }
 }

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/ShutdownHook.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/ShutdownHook.java
@@ -1,0 +1,47 @@
+package com.readytalk.cultivar;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.Beta;
+import com.google.common.annotations.VisibleForTesting;
+import com.readytalk.cultivar.management.ShutdownManager;
+
+/**
+ * Convenience tools for registering a shutdown hook.
+ */
+@Beta
+@ThreadSafe
+class ShutdownHook implements Runnable {
+    private static final Logger LOG = LoggerFactory.getLogger(ShutdownHook.class);
+
+    private final CultivarStartStopManager delegate;
+
+    @VisibleForTesting
+    ShutdownHook(final CultivarStartStopManager delegate) {
+        this.delegate = delegate;
+    }
+
+    public static void register(final CultivarStartStopManager cultivarManager,
+            @Nullable final ShutdownManager shutdownManager) {
+
+        if (shutdownManager == null) {
+            return;
+        }
+
+        shutdownManager.registerHook(new ShutdownHook(cultivarManager));
+
+    }
+
+    @Override
+    public void run() {
+        try {
+            delegate.stopAsync().awaitTerminated();
+        } catch (RuntimeException ex) {
+            LOG.warn("Exception while shutting down cultivar mangager: {}", delegate, ex);
+        }
+    }
+}

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/management/RuntimeShutdownHookManager.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/management/RuntimeShutdownHookManager.java
@@ -1,0 +1,30 @@
+package com.readytalk.cultivar.management;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.annotations.Beta;
+import com.google.inject.Inject;
+
+/**
+ * Registers a hook against a provided java.lang.Runtime.
+ */
+@Beta
+class RuntimeShutdownHookManager implements ShutdownManager {
+
+    private volatile Runtime runtime;
+
+    @Inject
+    RuntimeShutdownHookManager() {
+        runtime = Runtime.getRuntime();
+    }
+
+    @Inject(optional = true)
+    public void setRuntime(final Runtime runtime) {
+        this.runtime = checkNotNull(runtime, "Provided runtime cannot be null.");
+    }
+
+    @Override
+    public void registerHook(final Runnable hook) {
+        runtime.addShutdownHook(new Thread(checkNotNull(hook, "Hook cannot be null.")));
+    }
+}

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/management/RuntimeShutdownHookModule.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/management/RuntimeShutdownHookModule.java
@@ -1,0 +1,21 @@
+package com.readytalk.cultivar.management;
+
+import com.google.common.annotations.Beta;
+import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
+
+/**
+ * Binds a RuntimeShutdownHookManager to the ShutdownManager class that registers hooks against a provided runtime.
+ *
+ * Optional Bindings:
+ * <ul>
+ *     <li>: java.lang.Runtime (default: Runtime.getRuntime())</li>
+ * </ul>
+ */
+@Beta
+public class RuntimeShutdownHookModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(ShutdownManager.class).to(RuntimeShutdownHookManager.class).in(Scopes.SINGLETON);
+    }
+}

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/management/ShutdownManager.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/management/ShutdownManager.java
@@ -1,0 +1,11 @@
+package com.readytalk.cultivar.management;
+
+import com.google.common.annotations.Beta;
+
+/**
+ * Interface to abstract how to register a shutdown hook.
+ */
+@Beta
+public interface ShutdownManager {
+    void registerHook(final Runnable hook);
+}

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/management/package-info.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/management/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Tools for configuring shutdown/startup.
+ */
+@javax.annotation.ParametersAreNonnullByDefault
+package com.readytalk.cultivar.management;

--- a/cultivar-core/src/test/java/com/readytalk/cultivar/ShutdownHookTest.java
+++ b/cultivar-core/src/test/java/com/readytalk/cultivar/ShutdownHookTest.java
@@ -1,0 +1,81 @@
+package com.readytalk.cultivar;
+
+import com.readytalk.cultivar.management.ShutdownManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ShutdownHookTest {
+
+    @Mock
+    private CultivarStartStopManager cultivarManager;
+
+    @Mock
+    private ShutdownManager shutdownManager;
+
+    private ShutdownHook hook;
+
+    @Before
+    public void setUp() throws Exception {
+        when(cultivarManager.stopAsync()).thenReturn(cultivarManager);
+
+        hook = new ShutdownHook(cultivarManager);
+    }
+
+    @Test
+    public void register_NullManager_DoesNothing() {
+        ShutdownHook.register(cultivarManager, null);
+
+        verifyZeroInteractions(cultivarManager);
+    }
+
+    @Test
+    public void register_RegistersHook() {
+        ShutdownHook.register(cultivarManager, shutdownManager);
+
+        verify(shutdownManager).registerHook(any(ShutdownHook.class));
+    }
+
+    @Test
+    public void run_CleanRun_StopsThenAwaits() {
+        hook.run();
+
+        InOrder order = inOrder(cultivarManager);
+
+        order.verify(cultivarManager).stopAsync();
+        order.verify(cultivarManager).awaitTerminated();
+    }
+
+    @Test
+    public void run_RuntimeExceptionInStopAsync_DoesNotThrow() {
+        when(cultivarManager.stopAsync()).thenThrow(new RuntimeException("test"));
+
+        hook.run();
+
+        verify(cultivarManager).stopAsync();
+    }
+
+    @Test
+    public void run_RuntimeExceptionInAwaitTerminated_DoesNotThrow() {
+        doThrow(new RuntimeException("test")).when(cultivarManager).awaitTerminated();
+
+        hook.run();
+
+        verify(cultivarManager).awaitTerminated();
+    }
+
+
+}

--- a/cultivar-core/src/test/java/com/readytalk/cultivar/management/RuntimeShutdownHookManagerTest.java
+++ b/cultivar-core/src/test/java/com/readytalk/cultivar/management/RuntimeShutdownHookManagerTest.java
@@ -1,0 +1,55 @@
+package com.readytalk.cultivar.management;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+
+@SuppressWarnings("ConstantConditions")
+@RunWith(MockitoJUnitRunner.class)
+public class RuntimeShutdownHookManagerTest {
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    @Mock
+    private Runtime runtime;
+
+    @Mock
+    private Runnable runnable;
+
+    private RuntimeShutdownHookManager manager;
+
+    @Before
+    public void setUp() {
+        this.manager = new RuntimeShutdownHookManager();
+
+        manager.setRuntime(runtime);
+    }
+
+    @Test
+    public void setRuntime_NullRuntime_ThrowsNPE() {
+        thrown.expect(NullPointerException.class);
+
+        manager.setRuntime(null);
+    }
+
+    @Test
+    public void registerHook_NullHook_ThrowsNPE() {
+        thrown.expect(NullPointerException.class);
+
+        manager.registerHook(null);
+    }
+
+    @Test
+    public void registerHook_WithHook_RegistersAgainstRuntime() {
+        manager.registerHook(runnable);
+
+        verify(runtime).addShutdownHook(any(Thread.class));
+    }
+}

--- a/cultivar-core/src/test/java/com/readytalk/cultivar/management/RuntimeShutdownHookModuleTest.java
+++ b/cultivar-core/src/test/java/com/readytalk/cultivar/management/RuntimeShutdownHookModuleTest.java
@@ -1,0 +1,40 @@
+package com.readytalk.cultivar.management;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RuntimeShutdownHookModuleTest {
+
+    @Mock
+    private Runtime runtime;
+
+    @Mock
+    private Runnable runnable;
+
+    @Test
+    public void createInjector_NoParameters_Succeeds() {
+        assertNotNull(Guice.createInjector(new RuntimeShutdownHookModule()));
+    }
+
+    @Test
+    public void createInjector_BoundRuntime_BindsRuntime() {
+        Guice.createInjector(new RuntimeShutdownHookModule(), new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(Runtime.class).toInstance(runtime);
+            }
+        }).getInstance(ShutdownManager.class).registerHook(runnable);
+
+        verify(runtime).addShutdownHook(any(Thread.class));
+    }
+}

--- a/cultivar-discovery/src/integTest/java/com/readytalk/cultivar/discovery/RegistrationIntegTest.java
+++ b/cultivar-discovery/src/integTest/java/com/readytalk/cultivar/discovery/RegistrationIntegTest.java
@@ -18,8 +18,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ServiceManager;
@@ -51,8 +49,6 @@ public class RegistrationIntegTest extends AbstractZookeeperClusterTest {
     private ServiceProvider<Void> provider;
 
     private CultivarStartStopManager manager;
-
-    private ServiceManager registrationManager;
 
     @Before
     public void setUp() throws Exception {
@@ -95,14 +91,12 @@ public class RegistrationIntegTest extends AbstractZookeeperClusterTest {
                                 MoreExecutors.getExitingScheduledExecutorService(new ScheduledThreadPoolExecutor(1),
                                         10, TimeUnit.MILLISECONDS)).build());
 
-        registrationManager = inj.getInstance(Key.get(ServiceManager.class, Discovery.class));
+        ServiceManager registrationManager = inj.getInstance(Key.get(ServiceManager.class, Discovery.class));
 
         provider = inj.getInstance(Key.get(new TypeLiteral<ServiceProvider<Void>>() {
         }, Cultivar.class));
 
         manager = inj.getInstance(CultivarStartStopManager.class);
-
-        manager.startAsync().awaitRunning();
 
     }
 
@@ -117,17 +111,13 @@ public class RegistrationIntegTest extends AbstractZookeeperClusterTest {
 
     @After
     public void tearDown() throws Exception {
-        try {
-            registrationManager.stopAsync().awaitStopped();
-        } finally {
+        manager.stopAsync().awaitTerminated();
 
-            inj.getInstance(CultivarStartStopManager.class).stopAsync().awaitTerminated();
-        }
     }
 
     @Test
     public void provider_bothInstancesPopulated() throws Exception {
-        registrationManager.startAsync().awaitHealthy();
+        manager.startAsync().awaitRunning();
 
         awaitPopulation();
 

--- a/cultivar-discovery/src/main/java/com/readytalk/cultivar/discovery/RegistrationModule.java
+++ b/cultivar-discovery/src/main/java/com/readytalk/cultivar/discovery/RegistrationModule.java
@@ -5,10 +5,12 @@ import java.util.Set;
 import com.google.common.annotations.Beta;
 import com.google.common.util.concurrent.ServiceManager;
 import com.google.inject.AbstractModule;
+import com.google.inject.Key;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
+import com.readytalk.cultivar.Cultivar;
 
 @Beta
 public class RegistrationModule extends AbstractModule {
@@ -17,6 +19,9 @@ public class RegistrationModule extends AbstractModule {
     protected void configure() {
         Multibinder.newSetBinder(binder(), new TypeLiteral<RegistrationService<?>>() {
         });
+
+        Multibinder.newSetBinder(binder(), ServiceManager.class, Cultivar.class).addBinding()
+                .toProvider(getProvider(Key.get(ServiceManager.class, Discovery.class)));
     }
 
     @Provides

--- a/cultivar-discovery/src/main/java/com/readytalk/cultivar/discovery/RegistrationService.java
+++ b/cultivar-discovery/src/main/java/com/readytalk/cultivar/discovery/RegistrationService.java
@@ -1,7 +1,11 @@
 package com.readytalk.cultivar.discovery;
 
+import javax.annotation.concurrent.ThreadSafe;
+
 /**
  * Registers a service with discovery. Typed to represent the different payloads.
  */
+@ThreadSafe
 public interface RegistrationService<T> extends DiscoveryService {
+
 }

--- a/cultivar-discovery/src/main/java/com/readytalk/cultivar/discovery/ServiceDiscoveryManager.java
+++ b/cultivar-discovery/src/main/java/com/readytalk/cultivar/discovery/ServiceDiscoveryManager.java
@@ -5,11 +5,13 @@ import java.io.IOException;
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
 
-import com.readytalk.cultivar.internal.Private;
 import org.apache.curator.x.discovery.ServiceDiscovery;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.Beta;
 import com.google.common.util.concurrent.AbstractIdleService;
+import com.readytalk.cultivar.internal.Private;
 
 /**
  * Manages the lifecycle of a single ServiceDiscovery instance.
@@ -17,6 +19,7 @@ import com.google.common.util.concurrent.AbstractIdleService;
 @Beta
 @ThreadSafe
 public class ServiceDiscoveryManager<T> extends AbstractIdleService implements DiscoveryService {
+    private static final Logger LOG = LoggerFactory.getLogger(ServiceDiscoveryManager.class);
 
     private final ServiceDiscovery<T> discovery;
 
@@ -27,12 +30,15 @@ public class ServiceDiscoveryManager<T> extends AbstractIdleService implements D
 
     @Override
     protected void startUp() throws Exception {
-        discovery.start();
+        LOG.debug("Starting ServiceDiscoveryManager for ServiceDiscovery: {}", discovery);
 
+        discovery.start();
     }
 
     @Override
     protected void shutDown() throws IOException {
+        LOG.debug("Shutting down ServiceDiscoveryManager for ServiceDiscovery: {}", discovery);
+
         discovery.close();
     }
 }

--- a/cultivar-discovery/src/test/java/com/readytalk/cultivar/discovery/DefaultRegistrationServiceTest.java
+++ b/cultivar-discovery/src/test/java/com/readytalk/cultivar/discovery/DefaultRegistrationServiceTest.java
@@ -1,6 +1,8 @@
 package com.readytalk.cultivar.discovery;
 
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.ServiceInstance;
@@ -12,10 +14,10 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import com.google.common.base.VerifyException;
 import com.google.inject.util.Providers;
 
 @RunWith(MockitoJUnitRunner.class)
+@SuppressWarnings("unchecked")
 public class DefaultRegistrationServiceTest {
 
     @Rule
@@ -48,6 +50,17 @@ public class DefaultRegistrationServiceTest {
     }
 
     @Test
+    public void register_AlreadyRegistered_DoesNothing() throws Exception {
+        discoveryRegistration.register();
+
+        reset(discovery);
+
+        discoveryRegistration.register();
+
+        verifyZeroInteractions(discovery);
+    }
+
+    @Test
     public void shutDown_AfterStartUp_UnregistersService() throws Exception {
         discoveryRegistration.startUp();
 
@@ -57,9 +70,10 @@ public class DefaultRegistrationServiceTest {
     }
 
     @Test
-    public void shutDown_WithoutStartup_ThrowsVerifyException() throws Exception {
-        thrown.expect(VerifyException.class);
+    public void shutDown_WithoutStartup_DoesNothing() throws Exception {
 
         discoveryRegistration.shutDown();
+
+        verifyZeroInteractions(discovery);
     }
 }


### PR DESCRIPTION
Framework for allowing additional plugins to take advantage of the CultivarStartStopManager and facilities for shutting down cleanly.
- Allows additional plugins (e.g., Discovery) to start/stop themselves using the CultivarStartStopManager
- This utility was brought into the registration system added for Issue #10.
- Includes the ability to easily add a shutdown hook (Issue #21).
- Changes to improve/increase logging.
