### PR TITLE
Adding an ImmutableProperties object for easy discovery payloads.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,4 +19,5 @@ Changelog
 * Improved logging.
 * Improved documentation.
 * Easier unregistration/shutdown using either `java.lang.Runtime` shutdown hooks or customized shutdown systems (Issue #20).
-* Utilities for shutdown in a servlet environment. 
+* Utilities for shutdown in a servlet environment (Issue #21). 
+* ImmutableProperties payload object (Issue #40).

--- a/cultivar-discovery/src/integTest/java/com/readytalk/cultivar/discovery/payload/PayloadTypesIntegTest.java
+++ b/cultivar-discovery/src/integTest/java/com/readytalk/cultivar/discovery/payload/PayloadTypesIntegTest.java
@@ -1,0 +1,113 @@
+package com.readytalk.cultivar.discovery.payload;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.Callable;
+
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.ensemble.EnsembleProvider;
+import org.apache.curator.ensemble.fixed.FixedEnsembleProvider;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.x.discovery.ServiceInstance;
+import org.apache.curator.x.discovery.ServiceProvider;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Names;
+import com.google.inject.util.Providers;
+import com.readytalk.cultivar.Cultivar;
+import com.readytalk.cultivar.CultivarStartStopManager;
+import com.readytalk.cultivar.Curator;
+import com.readytalk.cultivar.CuratorModule;
+import com.readytalk.cultivar.discovery.RegistrationModule;
+import com.readytalk.cultivar.discovery.RegistrationServiceModuleBuilder;
+import com.readytalk.cultivar.discovery.ServiceDiscoveryModuleBuilder;
+import com.readytalk.cultivar.discovery.ServiceProviderModuleBuilder;
+import com.readytalk.cultivar.test.AbstractZookeeperClusterTest;
+import com.readytalk.cultivar.test.ConditionalWait;
+
+public class PayloadTypesIntegTest extends AbstractZookeeperClusterTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    private final ImmutableProperties props = ImmutableProperties.create(ImmutableMap.of("key", "value"));
+
+    private Injector inj;
+
+    private ServiceInstance<ImmutableProperties> service1;
+
+    private ServiceProvider<ImmutableProperties> provider;
+
+    private CultivarStartStopManager manager;
+
+    @Before
+    public void setUp() throws Exception {
+
+        service1 = ServiceInstance.<ImmutableProperties> builder().id("randomid").name("service").payload(props)
+                .build();
+
+        inj = Guice.createInjector(
+                new AbstractModule() {
+                    @Override
+                    protected void configure() {
+                        bindConstant().annotatedWith(Names.named("Cultivar.Curator.baseNamespace")).to("dev/test");
+                    }
+                },
+                new CuratorModule(new AbstractModule() {
+                    @Override
+                    protected void configure() {
+                        bind(EnsembleProvider.class).annotatedWith(Curator.class).toInstance(
+                                new FixedEnsembleProvider(testingCluster.getConnectString()));
+                        bind(RetryPolicy.class).annotatedWith(Curator.class).toInstance(
+                                new ExponentialBackoffRetry(1000, 3));
+
+                    }
+                }),
+                new RegistrationModule(),
+                ServiceDiscoveryModuleBuilder.create(ImmutableProperties.class).annotation(Curator.class)
+                        .basePath("/discovery").build(), ServiceProviderModuleBuilder.create(ImmutableProperties.class)
+                        .name("service").discovery(Curator.class).annotation(Cultivar.class).build(),
+                RegistrationServiceModuleBuilder.create(ImmutableProperties.class).discoveryAnnotation(Curator.class)
+                        .targetAnnotation(Curator.class).provider(Providers.of(service1)).build());
+
+        provider = inj.getInstance(Key.get(new TypeLiteral<ServiceProvider<ImmutableProperties>>() {
+        }, Cultivar.class));
+
+        manager = inj.getInstance(CultivarStartStopManager.class);
+
+    }
+
+    private void awaitPopulation() throws Exception {
+        new ConditionalWait(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return provider.getAllInstances().size() > 0;
+            }
+        }).await();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        manager.stopAsync().awaitTerminated();
+
+    }
+
+    @Test
+    public void provider_DeserializesProperties() throws Exception {
+        manager.startAsync().awaitRunning();
+
+        awaitPopulation();
+
+        assertEquals(props, provider.getInstance().getPayload());
+    }
+}

--- a/cultivar-discovery/src/main/java/com/readytalk/cultivar/discovery/payload/ImmutableProperties.java
+++ b/cultivar-discovery/src/main/java/com/readytalk/cultivar/discovery/payload/ImmutableProperties.java
@@ -1,0 +1,62 @@
+package com.readytalk.cultivar.discovery.payload;
+
+import java.util.Map;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.codehaus.jackson.annotate.JsonAutoDetect;
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonMethod;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Provides a simple String:String mapping class to use as a payload for discovery purposes.
+ */
+@JsonAutoDetect(value = JsonMethod.FIELD, fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@Immutable
+public class ImmutableProperties {
+    private final ImmutableMap<String, String> props;
+
+    protected ImmutableProperties(final Map<String, String> props) {
+        this.props = ImmutableMap.copyOf(props);
+    }
+
+    @JsonCreator
+    public static ImmutableProperties create(@JsonProperty("props") final Map<String, String> props) {
+        return new ImmutableProperties(props);
+    }
+
+    public Optional<String> get(final String key) {
+        return Optional.fromNullable(props.get(key));
+    }
+
+    public String get(final String key, final String def) {
+        return MoreObjects.firstNonNull(props.get(key), def);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(props);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (!(obj instanceof ImmutableProperties)) {
+            return false;
+        }
+
+        ImmutableProperties o = (ImmutableProperties) obj;
+
+        return Objects.equal(props, o.props);
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(props);
+    }
+}

--- a/cultivar-discovery/src/main/java/com/readytalk/cultivar/discovery/payload/package-info.java
+++ b/cultivar-discovery/src/main/java/com/readytalk/cultivar/discovery/payload/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Defaults for payloads.
+ */
+@javax.annotation.ParametersAreNonnullByDefault
+package com.readytalk.cultivar.discovery.payload;

--- a/cultivar-discovery/src/test/java/com/readytalk/cultivar/discovery/payload/ImmutablePropertiesTest.java
+++ b/cultivar-discovery/src/test/java/com/readytalk/cultivar/discovery/payload/ImmutablePropertiesTest.java
@@ -1,0 +1,135 @@
+package com.readytalk.cultivar.discovery.payload;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+@SuppressWarnings({ "ConstantConditions", "ObjectEqualsNull" })
+public class ImmutablePropertiesTest {
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    private final ImmutableMap<String, String> props = ImmutableMap.of("key", "value");
+
+    private ImmutableProperties immutableProperties;
+
+    @Before
+    public void setUp() {
+        immutableProperties = ImmutableProperties.create(props);
+    }
+
+    @Test
+    public void create_ValidMap_ReturnsNonNull() {
+        assertNotNull(ImmutableProperties.create(props));
+    }
+
+    @Test
+    public void create_NullMap_ThrowsNPE() {
+        thrown.expect(NullPointerException.class);
+
+        ImmutableProperties.create(null);
+    }
+
+    @Test
+    public void create_MapContainsNullValue_ThrowsNPE() {
+        thrown.expect(NullPointerException.class);
+
+        Map<String, String> map = Maps.newHashMap();
+
+        map.put("key", null);
+
+        ImmutableProperties.create(map);
+    }
+
+    @Test
+    public void create_MapContainsNullKey_ThrowsNPE() {
+        thrown.expect(NullPointerException.class);
+
+        Map<String, String> map = Maps.newHashMap();
+
+        map.put(null, "value");
+
+        ImmutableProperties.create(map);
+    }
+
+    @Test
+    public void get_AbsentKey_ReturnsAbsent() {
+        assertFalse("Value is present.", immutableProperties.get("notthere").isPresent());
+    }
+
+    @Test
+    public void get_PresentKey_ReturnsValue() {
+        assertEquals(props.get("key"), immutableProperties.get("key").get());
+    }
+
+    @Test
+    public void get_WithDefault_PresentKey_ReturnsValue() {
+        assertEquals(props.get("key"), immutableProperties.get("key", "def"));
+    }
+
+    @Test
+    public void get_WithDefault_AbsentKey_ReturnsDefault() {
+        assertEquals("def", immutableProperties.get("notthere", "def"));
+    }
+
+    @Test
+    public void get_WithNullDefault_AbsentKey_ThrowsNPE() {
+        thrown.expect(NullPointerException.class);
+
+        immutableProperties.get("notthere", null);
+    }
+
+    @Test
+    public void get_WithNullDefault_PresentKey_ReturnsValue() {
+
+        assertEquals(props.get("key"), immutableProperties.get("key", null));
+    }
+
+    @Test
+    public void equals_Null_ReturnsFalse() {
+        assertFalse(immutableProperties.equals(null));
+    }
+
+    @Test
+    public void equals_Self_ReturnsTrue() {
+        assertTrue(immutableProperties.equals(immutableProperties));
+    }
+
+    @Test
+    public void equals_DifferentObject_ReturnsFalse() {
+        assertFalse(immutableProperties.equals(props));
+    }
+
+    @Test
+    public void equals_Identical_ReturnsFalse() {
+        assertTrue(immutableProperties.equals(ImmutableProperties.create(props)));
+    }
+
+    @Test
+    public void hashCode_Identical_Equals() {
+        assertEquals(immutableProperties.hashCode(), ImmutableProperties.create(props).hashCode());
+    }
+
+    @Test
+    public void hashCode_DoesChange() {
+        assertTrue("Hash codes are equal despite changing the underlying map.",
+                immutableProperties.hashCode() != ImmutableProperties.create(ImmutableMap.of("key1", "value1"))
+                        .hashCode());
+    }
+
+    @Test
+    public void toString_ReturnsNotNull() {
+        assertNotNull(immutableProperties.toString());
+    }
+}

--- a/cultivar-servlets/src/main/java/com/readytalk/cultivar/servlets/ShutdownListenerModuleBuilder.java
+++ b/cultivar-servlets/src/main/java/com/readytalk/cultivar/servlets/ShutdownListenerModuleBuilder.java
@@ -37,7 +37,7 @@ public class ShutdownListenerModuleBuilder {
         }
     };
 
-    private ShutdownListenerModuleBuilder(final Class<? extends ServletContextListener> clazz) {
+    ShutdownListenerModuleBuilder(final Class<? extends ServletContextListener> clazz) {
         this.clazz = clazz;
     }
 


### PR DESCRIPTION
Useful for tests and simple systems, also makes for a demo of using Jackson Annotations with Curator payloads. 

Addresses Issue #40.
