### PR TITLE
Updating curator and checkstyle.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,3 +24,5 @@ Changelog
 
 1.4.0
 -----
+
+* Updated Curator to 2.7.0 and Checkstyle to 6.0.

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ subprojects {
   version = '1.4.0-SNAPSHOT'
   
   project.ext.libVersions = [
-    curator: "2.6.0",
+    curator: "2.7.0",
     slf4j: "1.7.7",
     logback: "1.1.2",
     findbugs: "2.0.3",
@@ -86,7 +86,7 @@ subprojects {
   }
   
   checkstyle {
-    toolVersion = '5.7'
+    toolVersion = '6.0'
     showViolations = true
     sourceSets = [sourceSets.main]
     configFile = file("$rootDir/config/checkstyle/checkstyle.xml")

--- a/cultivar-core/src/integTest/java/com/readytalk/cultivar/namespace/NamespaceModuleBuilderIntegTest.java
+++ b/cultivar-core/src/integTest/java/com/readytalk/cultivar/namespace/NamespaceModuleBuilderIntegTest.java
@@ -68,14 +68,14 @@ public class NamespaceModuleBuilderIntegTest extends AbstractZookeeperClusterTes
     public void namespacedNullFramework_HasNullNamespace() {
 
         assertNull(namespacedNullFramework.getNamespace());
-        assertEquals("test", namespacedNullFramework.newNamespaceAwareEnsurePath("test").getPath());
+        assertEquals("/test", namespacedNullFramework.newNamespaceAwareEnsurePath("/test").getPath());
     }
 
     @Test
     public void namespacedFooFramework_HasFooNamespace() {
 
         assertEquals("foo", namespacedFooFramework.getNamespace());
-        assertEquals("/foo/test", namespacedFooFramework.newNamespaceAwareEnsurePath("test").getPath());
+        assertEquals("/foo/test", namespacedFooFramework.newNamespaceAwareEnsurePath("/test").getPath());
     }
 
 }

--- a/cultivar-core/src/integTest/java/com/readytalk/cultivar/namespace/NamespacesIntegTest.java
+++ b/cultivar-core/src/integTest/java/com/readytalk/cultivar/namespace/NamespacesIntegTest.java
@@ -68,13 +68,13 @@ public class NamespacesIntegTest extends AbstractZookeeperClusterTest {
     public void namespacedNullFramework_HasNullNamespace() {
 
         assertNull(namespacedNullFramework.getNamespace());
-        assertEquals("test", namespacedNullFramework.newNamespaceAwareEnsurePath("test").getPath());
+        assertEquals("/test", namespacedNullFramework.newNamespaceAwareEnsurePath("/test").getPath());
     }
 
     @Test
     public void namespacedFooFramework_HasFooNamespace() {
 
         assertEquals("foo", namespacedFooFramework.getNamespace());
-        assertEquals("/foo/test", namespacedFooFramework.newNamespaceAwareEnsurePath("test").getPath());
+        assertEquals("/foo/test", namespacedFooFramework.newNamespaceAwareEnsurePath("/test").getPath());
     }
 }

--- a/cultivar-core/src/main/java/com/readytalk/cultivar/barriers/DistributedDoubleBarrierFactory.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/barriers/DistributedDoubleBarrierFactory.java
@@ -1,13 +1,15 @@
 package com.readytalk.cultivar.barriers;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import javax.annotation.Nonnegative;
 import javax.inject.Inject;
 
-import com.google.common.annotations.Beta;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.barriers.DistributedDoubleBarrier;
+
+import com.google.common.annotations.Beta;
 import com.readytalk.cultivar.Curator;
 
 /**
@@ -25,6 +27,6 @@ public class DistributedDoubleBarrierFactory {
     public DistributedDoubleBarrier create(final String barrierPath, @Nonnegative final int memberQty) {
         checkArgument(memberQty > 0, "Member quantity must be greater than zero.");
 
-        return new DistributedDoubleBarrier(framework, barrierPath, memberQty);
+        return new DistributedDoubleBarrier(framework, checkNotNull(barrierPath, "Path cannot be null."), memberQty);
     }
 }

--- a/cultivar-core/src/test/java/com/readytalk/cultivar/cache/NodeContainerModuleBuilderTest.java
+++ b/cultivar-core/src/test/java/com/readytalk/cultivar/cache/NodeContainerModuleBuilderTest.java
@@ -175,7 +175,7 @@ public class NodeContainerModuleBuilderTest {
             when(framework.newNamespaceAwareEnsurePath(anyString())).thenReturn(ensurePath);
 
             Module module = NodeContainerModuleBuilder.create(String.class).annotation(Curator.class)
-                    .mapper(StringUTF8ByteArrayMapper.class).path("dev/test").build();
+                    .mapper(StringUTF8ByteArrayMapper.class).path("/dev/test").build();
             injector = Guice.createInjector(Stage.PRODUCTION, new AbstractModule() {
                 @Override
                 protected void configure() {


### PR DESCRIPTION
Updating Curator had some unanticipated side effects due to issues that were addressed
in CURATOR-136 ( https://github.com/apache/curator/commit/05254afea628a1018e1058d230a568746f98df5a#diff-987cef79524e0a6cb118d2df685f041d ).

The first issue is that by validating the path earlier in the distributed double barrier it caused it throw an IAE instead of a NPE
when the path was null. Since Cultivar consistently uses checkNotNull to check for null in these cases the fix was to add checkNotNull
into the factory.

The second issue is that, previously, `framework.newNamespaceAwareEnsurePath("test")` would work if framework was a CuratorFramework with
a null namespace. That is no longer the case, requiring it to be "/test" instead.  This also changed the response from getPath that was then
called on the newNamespaceAwareEnsurePath.
