### PR TITLE
Increasing consistency in use of generics.

### DIFF
--- a/cultivar-core/src/main/java/com/readytalk/cultivar/leader/LeaderServiceModuleBuilder.java
+++ b/cultivar-core/src/main/java/com/readytalk/cultivar/leader/LeaderServiceModuleBuilder.java
@@ -32,13 +32,13 @@ public final class LeaderServiceModuleBuilder<T extends LeaderService> {
         this.key = checkNotNull(key);
     }
 
-    public LeaderServiceModuleBuilder implementation(final TypeLiteral<? extends T> clazz) {
+    public LeaderServiceModuleBuilder<T> implementation(final TypeLiteral<? extends T> clazz) {
         this.implementation = checkNotNull(clazz);
 
         return this;
     }
 
-    public LeaderServiceModuleBuilder implementation(final Class<? extends T> clazz) {
+    public LeaderServiceModuleBuilder<T> implementation(final Class<? extends T> clazz) {
         return implementation(TypeLiteral.get(clazz));
     }
 
@@ -46,7 +46,7 @@ public final class LeaderServiceModuleBuilder<T extends LeaderService> {
         return new LeaderServiceModuleBuilder<T>(checkNotNull(key));
     }
 
-    public LeaderServiceModuleBuilder dependencies(final Module... modules) {
+    public LeaderServiceModuleBuilder<T> dependencies(final Module... modules) {
         checkState(dependencies == null, "Dependencies were already set.");
         checkArgument(modules.length > 0);
 

--- a/cultivar-discovery/src/main/java/com/readytalk/cultivar/discovery/RegistrationServiceModuleBuilder.java
+++ b/cultivar-discovery/src/main/java/com/readytalk/cultivar/discovery/RegistrationServiceModuleBuilder.java
@@ -171,6 +171,7 @@ public class RegistrationServiceModuleBuilder<T> {
      *            An optional ScheduledExecutorService. By default this will be an exitingScheduledExecutorService with
      *            default parameters.
      */
+    @SuppressWarnings("unchecked")
     public RegistrationServiceModuleBuilder<T> updating(@Nonnegative final long time, final TimeUnit unit,
             final ScheduledExecutorService service) {
         checkArgument(time > 0, "Time must be positive.");

--- a/cultivar-test/src/main/java/com/readytalk/cultivar/test/AbstractZookeeperClusterTest.java
+++ b/cultivar-test/src/main/java/com/readytalk/cultivar/test/AbstractZookeeperClusterTest.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.Beta;
+import com.google.common.base.Stopwatch;
 
 @Beta
 public abstract class AbstractZookeeperClusterTest {
@@ -29,10 +30,14 @@ public abstract class AbstractZookeeperClusterTest {
         protected void before() throws Throwable {
             super.before();
 
+            Stopwatch stopwatch = Stopwatch.createStarted();
+
+            LOG.info("Attempting to start ZK cluster: {}", testingCluster.getConnectString());
+
             testingCluster.start();
 
-            LOG.info("{}-servers started with connection string: {}", testingCluster.getServers().size(),
-                    testingCluster.getConnectString());
+            LOG.info("{}-servers started in {} milliseconds with connection string: {}", testingCluster.getServers()
+                    .size(), stopwatch.stop().elapsed(TimeUnit.MILLISECONDS), testingCluster.getConnectString());
         }
 
         @Override


### PR DESCRIPTION
1. Removes some of the generics warnings that show up in Java 7+.
2. Add logging to help diagnose test failures. 
